### PR TITLE
Small changes needed in training overview

### DIFF
--- a/docs_src/training.ipynb
+++ b/docs_src/training.ipynb
@@ -46,7 +46,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We'll do a quick overview of the key pieces of fastai's training modules. See the separate module docs for details on each. We'll use the classic MNIST dataset for the training documentation, cut down to just 3's and 7's. To minimize the boilerplate in our docs we've defined the basic imports and paths we need in [`fastai.docs`](/docs.html#docs). It also has a [`get_mnist`](/docs.html#get_mnist) function to grab a [`DataBunch`](/data.html#DataBunch) of the data for us, which will automatically download and unzip the data if not already done."
+    "We'll do a quick overview of the key pieces of fastai's training modules. See the separate module docs for details on each. We'll use the classic MNIST dataset for the training documentation, cut down to just 3's and 7's. To minimize the boilerplate in our docs we've defined the basic imports and paths we need in [`fastai.docs`](/docs.html#docs). It also has a [`get_mnist`](/docs.html#get_mnist) function to grab a [`DataBunch`](/data.html#DataBunch) of the data for us, which will automatically download and unzip the data if not already done. Note that you will need to create a `../data` directory beforehand."
    ]
   },
   {
@@ -58,7 +58,8 @@
    "outputs": [],
    "source": [
     "from fastai.docs import *\n",
-    "data = get_mnist()"
+    "from fastai import *\n",
+    "mnist_data = get_mnist()"
    ]
   },
   {
@@ -97,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "learn = Learner(data, model)"
+    "learn = Learner(mnist_data, model)"
    ]
   },
   {


### PR DESCRIPTION
Hello, I found I needed to make some small tweaks to get the training overview to run. I had to

1.  create a `../data` directory for the MNIST files,
2. add `from fastai import *` or `simple_cnn` was not found, and 
3. rename the MNIST data from `data` to `mnist_data` to avoid a name clash (thanks to the `import *` business).

I think the first two items are probably due to unintended behavior deeper in the library.

Also, I apologize if I didn't include everything in the commit needed here - this form of documentation is new to me (but it is very cool!).

Thanks!