### PR TITLE
Change output layer in tabular example from 100 to 2

### DIFF
--- a/docs/tabular.html
+++ b/docs/tabular.html
@@ -52,7 +52,7 @@ summary: "Application to tabular/structured data"
 <span class="n">ADULT_PATH</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -82,7 +82,7 @@ summary: "Application to tabular/structured data"
 <span class="n">df</span><span class="o">.</span><span class="n">head</span><span class="p">()</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -238,7 +238,7 @@ summary: "Application to tabular/structured data"
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">tfms</span> <span class="o">=</span> <span class="p">[</span><span class="n">FillMissing</span><span class="p">,</span> <span class="n">Categorify</span><span class="p">]</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -258,7 +258,7 @@ summary: "Application to tabular/structured data"
 <div class=" highlight hl-ipython3"><pre><span></span><span class="n">train_df</span><span class="p">,</span> <span class="n">valid_df</span> <span class="o">=</span> <span class="n">df</span><span class="p">[:</span><span class="o">-</span><span class="mi">2000</span><span class="p">]</span><span class="o">.</span><span class="n">copy</span><span class="p">(),</span><span class="n">df</span><span class="p">[</span><span class="o">-</span><span class="mi">2000</span><span class="p">:]</span><span class="o">.</span><span class="n">copy</span><span class="p">()</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -279,7 +279,7 @@ summary: "Application to tabular/structured data"
 <span class="n">cat_names</span> <span class="o">=</span> <span class="p">[</span><span class="s1">&#39;workclass&#39;</span><span class="p">,</span> <span class="s1">&#39;education&#39;</span><span class="p">,</span> <span class="s1">&#39;marital-status&#39;</span><span class="p">,</span> <span class="s1">&#39;occupation&#39;</span><span class="p">,</span> <span class="s1">&#39;relationship&#39;</span><span class="p">,</span> <span class="s1">&#39;race&#39;</span><span class="p">,</span> <span class="s1">&#39;sex&#39;</span><span class="p">,</span> <span class="s1">&#39;native-country&#39;</span><span class="p">]</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -300,7 +300,7 @@ summary: "Application to tabular/structured data"
 <span class="nb">print</span><span class="p">(</span><span class="n">data</span><span class="o">.</span><span class="n">train_ds</span><span class="o">.</span><span class="n">cont_names</span><span class="p">)</span>  <span class="c1"># `cont_names` defaults to: set(df)-set(cat_names)-{dep_var}</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -335,7 +335,7 @@ summary: "Application to tabular/structured data"
 <span class="k">for</span> <span class="n">o</span> <span class="ow">in</span> <span class="p">(</span><span class="n">cat_x</span><span class="p">,</span> <span class="n">cont_x</span><span class="p">,</span> <span class="n">y</span><span class="p">):</span> <span class="nb">print</span><span class="p">(</span><span class="n">to_np</span><span class="p">(</span><span class="n">o</span><span class="p">[:</span><span class="mi">5</span><span class="p">]))</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -389,11 +389,11 @@ summary: "Application to tabular/structured data"
 
 <div class="inner_cell">
     <div class="input_area">
-<div class=" highlight hl-ipython3"><pre><span></span><span class="n">learn</span> <span class="o">=</span> <span class="n">get_tabular_learner</span><span class="p">(</span><span class="n">data</span><span class="p">,</span> <span class="n">layers</span><span class="o">=</span><span class="p">[</span><span class="mi">200</span><span class="p">,</span><span class="mi">100</span><span class="p">],</span> <span class="n">emb_szs</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;native-country&#39;</span><span class="p">:</span> <span class="mi">10</span><span class="p">},</span> <span class="n">metrics</span><span class="o">=</span><span class="n">accuracy</span><span class="p">)</span>
+<div class=" highlight hl-ipython3"><pre><span></span><span class="n">learn</span> <span class="o">=</span> <span class="n">get_tabular_learner</span><span class="p">(</span><span class="n">data</span><span class="p">,</span> <span class="n">layers</span><span class="o">=</span><span class="p">[</span><span class="mi">200</span><span class="p">,</span><span class="mi">2</span><span class="p">],</span> <span class="n">emb_szs</span><span class="o">=</span><span class="p">{</span><span class="s1">&#39;native-country&#39;</span><span class="p">:</span> <span class="mi">10</span><span class="p">},</span> <span class="n">metrics</span><span class="o">=</span><span class="n">accuracy</span><span class="p">)</span>
 <span class="n">learn</span><span class="o">.</span><span class="n">fit_one_cycle</span><span class="p">(</span><span class="mi">1</span><span class="p">,</span> <span class="mf">1e-2</span><span class="p">)</span>
 </pre></div>
 
-</div>
+    </div>
 </div>
 </div>
 
@@ -407,10 +407,10 @@ summary: "Application to tabular/structured data"
 
  
  
-<div id="a502b845-c638-4ba0-af91-42442791b316"></div>
+<div id="869bd327-5b23-475b-8a54-c19f1fc6da31"></div>
 <div class="output_subarea output_widget_view ">
 <script type="text/javascript">
-var element = $('#a502b845-c638-4ba0-af91-42442791b316');
+var element = $('#869bd327-5b23-475b-8a54-c19f1fc6da31');
 </script>
 <script type="application/vnd.jupyter.widget-view+json">
 {"model_id": "", "version_major": 2, "version_minor": 0}
@@ -424,7 +424,7 @@ var element = $('#a502b845-c638-4ba0-af91-42442791b316');
 <div class="output_subarea output_stream output_stdout output_text">
 <pre>Total time: 00:04
 epoch  train loss  valid loss  accuracy
-0      0.349120    0.349844    0.839500  (00:04)
+0      0.324364    0.320271    0.846500  (00:04)
 
 </pre>
 </div>

--- a/docs_src/tabular.ipynb
+++ b/docs_src/tabular.ipynb
@@ -390,13 +390,13 @@
      "text": [
       "Total time: 00:04\n",
       "epoch  train loss  valid loss  accuracy\n",
-      "0      0.328808    0.370992    0.836000  (00:04)\n",
+      "0      0.324364    0.320271    0.846500  (00:04)\n",
       "\n"
      ]
     }
    ],
    "source": [
-    "learn = get_tabular_learner(data, layers=[200,100], emb_szs={'native-country': 10}, metrics=accuracy)\n",
+    "learn = get_tabular_learner(data, layers=[200,2], emb_szs={'native-country': 10}, metrics=accuracy)\n",
     "learn.fit_one_cycle(1, 1e-2)"
    ]
   }


### PR DESCRIPTION
Since the output for our dataset can only be 2 values, 0 or 1,
the network simply learns to ignore 98 out of the 100 outputs.

I found it confusing that we'd end up with 100 outputs given that
this is a binary classification problem, so I figured updating the docs
would help others understand this as well.