### PR TITLE
Typos in `index.ipynb`

### DIFF
--- a/docs_src/index.ipynb
+++ b/docs_src/index.ipynb
@@ -134,7 +134,7 @@
    "source": [
     "To get started quickly, click *Applications* on the sidebar, and then choose the application you're interested in. That will take you to a walk-through of training a model of that type. You can then either explore the various links from there, or dive more deeply into the various fastai modules.\n",
     "\n",
-    "We've provided below a quick summary of the key modules in this library. For details on each one, use the sidebar to find the module you're interested in. Each module includes an overview and example of how to use it, along with documentation for every class, function, and method. API documentation looks, for example, like this:\n",
+    "We've provided below a quick summary of the key modules in this library. For details on each one, use the sidebar to find the module you're interested in. Each module includes an overview, an example of how to use it, along with documentation for every class, function, and method. API documentation looks, for example, like this:\n",
     "\n",
     "### An example function"
    ]
@@ -253,15 +253,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "At the base of everything are the two modules [`core`](/core.html#core) and [`torch_core`](/torch_core.html#torch_core) (we're not including the `fastai.` prefix when naming modules in these docs). They define the basic functions we use in the library; [`core`](/core.html#core) only relies on general modules, whereas [`torch_core`](/torch_core.html#torch_core) requires pytorch. Most type-hinting shortcuts are defined there too (at least the one that don't depend on fastai classes defined later). Nearly all modules below import [`torch_core`](/torch_core.html#torch_core).\n",
+    "At the base of everything are the two modules [`core`](/core.html#core) and [`torch_core`](/torch_core.html#torch_core) (we're not including the `fastai.` prefix when naming modules in these docs). They define the basic functions we use in the library; [`core`](/core.html#core) only relies on general modules, whereas [`torch_core`](/torch_core.html#torch_core) requires pytorch. Most type-hinting shortcuts are defined there too (at least the ones that don't depend on fastai classes defined later). Nearly all modules below import [`torch_core`](/torch_core.html#torch_core).\n",
     "\n",
     "Then, there are three modules directly on top of [`torch_core`](/torch_core.html#torch_core): \n",
     "- [`data`](/data.html#data), which contains the class that will take a [`Dataset`](https://pytorch.org/docs/stable/data.html#torch.utils.data.Dataset) or pytorch [`DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader) to wrap it in a [`DeviceDataLoader`](/data.html#DeviceDataLoader) (a class that sits on top of a [`DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader) and is in charge of putting the data on the right device as well as applying transforms such as normalization) and regroup then in a [`DataBunch`](/data.html#DataBunch).\n",
     "- [`layers`](/layers.html#layers), which contains basic functions to define custom layers or groups of layers\n",
     "- [`metrics`](/metrics.html#metrics), which contains all the metrics\n",
     "\n",
-    "From [`layers`](/layers.html#layers), we have all the modules in the models folder that are defined. Then from [`data`](/data.html#data) we can split on one of the four main *applications*, which each has their own module: [`vision`](/vision.html#vision), [`text`](/text.html#text) [`collab`](/collab.html#collab), or [`tabular`](/tabular.html#tabular). Each of those submodules is built in the same way with:\n",
-    "- a submodule named [`transform`](/text.transform.html#text.transform) that handles the transformations of our data (data augmentation for computer vision, numericalizing and tokenizing for text and preprocessing for tabular)\n",
+    "From [`layers`](/layers.html#layers), we have all the modules in the models folder that are defined. Then from [`data`](/data.html#data) we can split on one of the four main *applications*, which each has their own module: [`vision`](/vision.html#vision), [`text`](/text.html#text), [`collab`](/collab.html#collab), or [`tabular`](/tabular.html#tabular). Each of those submodules is built in the same way with:\n",
+    "- a submodule named [`transform`](/text.transform.html#text.transform) that handles the transformations of our data (data augmentation for computer vision, numericalizing and tokenizing for text, and preprocessing for tabular)\n",
     "- a submodule named [`data`](/data.html#data) that contains the class that will create datasets and the helper functions to create [`DataBunch`](/data.html#DataBunch) objects.\n",
     "\n",
     "This takes care of building your model and handling the data. We regroup those in a [`Learner`](/basic_train.html#Learner) object to take care of training. More specifically:\n",


### PR DESCRIPTION
In reading the new docs for the V1 release, I'm finding a few minor typos.  I can keep these separated by files like this one for just `index.ipynb` or lump them together if preferred.   If this is helpful, let me know.