### PR TITLE
Typo: Fix wrong size

### DIFF
--- a/docs_src/vision.data.ipynb
+++ b/docs_src/vision.data.ipynb
@@ -99,7 +99,7 @@
    "source": [
     "Here the datasets will be automatically created from the structure above, and we precise:\n",
     "- the transforms to apply to the images in `ds_tfms` (here with `do_flip`=False because we don't want to flip numbers),\n",
-    "- the target `size` of our pictures (here 28).\n",
+    "- the target `size` of our pictures (here 24).\n",
     "\n",
     "As all [`DataBunch`](/data.html#DataBunch), data then as a `train_dl` and a `valid_dl` that are [`DataLoader`](https://pytorch.org/docs/stable/data.html#torch.utils.data.DataLoader). If you want to have a look at a few images in a batch inside a batch, you can use [`show_image_batch`](/vision.data.html#show_image_batch), the `rows` argument being the number of rows and columns in the array."
    ]


### PR DESCRIPTION
Small typo. The code says 24, the docs said 28. Now it's 24 everywhere.

Do I also need to generate and add the HTML?