### PR TITLE
Update vision.ipynb

### DIFF
--- a/docs_src/vision.ipynb
+++ b/docs_src/vision.ipynb
@@ -343,7 +343,7 @@
     "tds = DatasetTfm(ds, tfms)\n",
     "\n",
     "fig,axes = plt.subplots(1,4,figsize=(8,2))\n",
-    "for ax in axes: apply_tfms(tfms, ds[0][0]).show(ax=ax)"
+    "for ax in axes: tds[0][0].show(ax=ax)"
    ]
   },
   {


### PR DESCRIPTION
Looks like this cell show be either:
```
fig,axes = plt.subplots(1,4,figsize=(8,2))
for ax in axes: apply_tfms(tfms, ds[0][0]).show(ax=ax)
```
or
```tds = DatasetTfm(ds, tfms)

fig,axes = plt.subplots(1,4,figsize=(8,2))
for ax in axes: tds[0][0].show(ax=ax)
```
instead of its current way where `tds = DatasetTfm(ds, tfms)` is redundent. 