### PR TITLE
Adding anchors to page titles

### DIFF
--- a/docs/_layouts/page.html
+++ b/docs/_layouts/page.html
@@ -3,7 +3,8 @@ layout: default
 ---
 
 <div class="post-header">
-   <h1 class="post-title-main">{{ page.title }}</h1>
+    <a id="{{page.title}}"></a>
+    <h1 class="post-title-main">{{ page.title }}</h1>
 </div>
 
 {% if page.simple_map == true %}


### PR DESCRIPTION
Adds anchor to top level module - similar to [pytorch](https://pytorch.org/docs/stable/storage.html#torch-storage) 

This will fix a lot of the missing anchors found here https://github.com/fastai/fastai_docs/commit/59e35ca61284cbf2d4fb7c2dc844c83292aaed7f