### PR TITLE
fix shape in ActivationStats

### DIFF
--- a/docs_src/callbacks.hooks.ipynb
+++ b/docs_src/callbacks.hooks.ipynb
@@ -107,7 +107,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The saved `stats` is a `FloatTensor` of shape `(2,num_batches,num_modules)`. The first axis is `(mean,stdev)`."
+    "The saved `stats` is a `FloatTensor` of shape `(2,num_modules,num_batches)`. The first axis is `(mean,stdev)`."
    ]
   },
   {


### PR DESCRIPTION
Fix the order of axis in ActivationStats.stats.shape  from (2,num_batches,num_modules) to (2,num_modules,num_batches).

Link in forum: [stats shape](https://forums.fast.ai/t/developer-chat/22363/320)