### PR TITLE
print containing folder in output path

### DIFF
--- a/dev_course/dl2/notebook2script.py
+++ b/dev_course/dl2/notebook2script.py
@@ -25,8 +25,9 @@ def notebook2script(fname):
     for cell in code_cells: module += ''.join(cell['source'][1:]) + '\n\n'
     # remove trailing spaces
     module = re.sub(r' +$', '', module, flags=re.MULTILINE)
-    open(fname.parent/'exp'/fname_out,'w').write(module[:-2])
-    print(f"Converted {fname} to {fname_out}")
+    output_path = fname.parent/'exp'/fname_out
+    open(output_path,'w').write(module[:-2])
+    print(f"Converted {fname} to {output_path}")
 
 if __name__ == '__main__': fire.Fire(notebook2script)
 


### PR DESCRIPTION
The `notebook2script.py` script should print output folder name. I didn't know the output file is in the `exp` folder until I read the source code.

Command:
```sh
!python notebook2script.py 00_exports.ipynb
```

Before:
Converted 00_exports.ipynb to nb_00.py

After:
Converted 00_exports.ipynb to exp/nb_00.py
