### PR TITLE
Update how number of categories is calculated

### DIFF
--- a/dev_course/dl2/02a_why_sqrt5.ipynb
+++ b/dev_course/dl2/02a_why_sqrt5.ipynb
@@ -98,7 +98,7 @@
    ],
    "source": [
     "n,*_ = x_train.shape\n",
-    "c = y_train.max()+1\n",
+    "c = torch.tensor(y_train.unique().numel())\n",
     "nh = 32\n",
     "n,c"
    ]


### PR DESCRIPTION
I am proposing to modify how the variable `c` is being calculated.  I believe this would be more robust for future use-cases.  A few examples where this update would solve issues:
1. Not all digits show up in the sample.  Assuming only 1,4,7, and 9 are present in the sample, c should only equal 4, but with the current code, it would still equal 10.  
2. Better for other datasets

The con of this solution is that it is slower than what is currently being used.  Since it relies on unique it is quite a bit slower than what is currently being used.  Not enough to matter for this example, but if there are other better solutions or suggestions, I would be interested in seeing them!