### PR TITLE
Fix references to variance, add clarity

### DIFF
--- a/dev_course/dl2/02b_initializing.ipynb
+++ b/dev_course/dl2/02b_initializing.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -54,7 +54,7 @@
        "(tensor(nan), tensor(nan))"
       ]
      },
-     "execution_count": 38,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -102,7 +102,7 @@
        "27"
       ]
      },
-     "execution_count": 41,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -120,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -148,7 +148,7 @@
        "(tensor(0.), tensor(0.))"
       ]
      },
-     "execution_count": 44,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -183,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +211,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -220,7 +220,7 @@
        "(tensor(0.0982), tensor(4.2881))"
       ]
      },
-     "execution_count": 48,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -238,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -247,7 +247,7 @@
        "0.044194173824159216"
       ]
      },
-     "execution_count": 49,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -274,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -283,7 +283,7 @@
        "(tensor(-0.0648), tensor(0.9609))"
       ]
      },
-     "execution_count": 50,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -311,7 +311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 52,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -320,7 +320,7 @@
        "(-0.000560310110449791, 508.57024475097654)"
       ]
      },
-     "execution_count": 52,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -348,7 +348,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -357,7 +357,7 @@
        "(-0.351292731320858, 517.5591897146537)"
       ]
      },
-     "execution_count": 58,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -529,7 +529,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -538,7 +538,7 @@
        "(-0.3848510993003845, 505.62580416496115)"
       ]
      },
-     "execution_count": 55,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -670,7 +670,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 56,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -679,7 +679,7 @@
        "(0.006510300114750862, 1.0147866140232764)"
       ]
      },
-     "execution_count": 56,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -707,7 +707,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 57,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -716,7 +716,7 @@
        "(0.003834125765133649, 0.9961219137907028)"
       ]
      },
-     "execution_count": 57,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -867,18 +867,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.2"
   }
  },
  "nbformat": 4,

--- a/dev_course/dl2/02b_initializing.ipynb
+++ b/dev_course/dl2/02b_initializing.ipynb
@@ -99,7 +99,7 @@
     {
      "data": {
       "text/plain": [
-       "27"
+       "28"
       ]
      },
      "execution_count": null,
@@ -217,7 +217,7 @@
     {
      "data": {
       "text/plain": [
-       "(tensor(0.0982), tensor(4.2881))"
+       "(tensor(0.0144), tensor(0.5380))"
       ]
      },
      "execution_count": null,
@@ -280,7 +280,7 @@
     {
      "data": {
       "text/plain": [
-       "(tensor(-0.0648), tensor(0.9609))"
+       "(tensor(0.0188), tensor(0.9201))"
       ]
      },
      "execution_count": null,
@@ -317,7 +317,7 @@
     {
      "data": {
       "text/plain": [
-       "(-0.000560310110449791, 508.57024475097654)"
+       "(-0.020908803418278693, 505.53545623779297)"
       ]
      },
      "execution_count": null,
@@ -354,7 +354,7 @@
     {
      "data": {
       "text/plain": [
-       "(-0.351292731320858, 517.5591897146537)"
+       "(0.08155614581108094, tensor(512.1214))"
       ]
      },
      "execution_count": null,
@@ -363,15 +363,17 @@
     }
    ],
    "source": [
-    "mean,sqr = 0.,0.\n",
+    "mean, var = 0.0, 0.0\n",
     "n_iter = 10000\n",
+    "n_dim = 512\n",
+    "ys = []\n",
     "for i in range(n_iter):\n",
-    "    x = torch.randn(512)\n",
-    "    a = torch.randn(512) #just like one row of a\n",
-    "    y = a @x\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim) #just like one row of a\n",
+    "    y = a@x\n",
     "    mean += y.item()\n",
-    "    sqr  += y.pow(2).item()\n",
-    "mean/10000,sqr/10000"
+    "    ys.append(y.item())\n",
+    "mean/n_iter, torch.tensor(ys).var()"
    ]
   },
   {
@@ -399,7 +401,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let $A$ be the random variable from which $a$ is taken, and $X$ be the random variable from which $x$ is taken. Let $y$ be the random variable from which $Y$ is sampled.  We know that one element of $Y$ is created by multiplying 512 elements from $A$ and $X$ with each other. That is, we sample 512 elements from $A$, 512 elements from $X$ and multiply them with each other. Thus, so far we have:\n"
+    "Let $A$, $X$ and $Y$ be the random variables from which $a$, $x$ and $y$ are sampled respectively. We know that one element of $Y$ is created by multiplying 512 elements from $A$ and $X$ with each other. That is, we sample 512 elements from $A$, 512 elements from $X$, multiply them element by element, and add them. Thus, so far we have:\n"
    ]
   },
   {
@@ -450,7 +452,7 @@
     "$\n",
     "\\begin{align}\n",
     "E[Y] & = E[AX] \\\\\n",
-    "& = E[A] * E[X] = 0 \\ (\\because E[A] = E[X] = 0)\n",
+    "& = E[A] * E[X] = 0 & (\\text{A and X are independent, and E[A] = E[X] = 0})\n",
     "\\end{align}\n",
     "$"
    ]
@@ -466,7 +468,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's first calculate the variance of $AX$. That is, what would be the variance if we pick one element randomly from $A$ and $X$ and then multiply them?"
+    "We know that $Y$ is created by adding 512 elements sampled from $A*X$. Thus, let's first calculate the variance of $A*X$. That is, what would be the variance if we pick one element randomly from $A$ and $X$ and then multiply them?"
    ]
   },
   {
@@ -475,8 +477,9 @@
    "source": [
     "$\n",
     "\\begin{align}\n",
-    "Var[AX] & = Var(A)*(E(X))^2 + Var(X)*(E(A))^2 + Var(A)*Var(X) \\\\\n",
-    " & = Var(A) * Var(X) = 1\n",
+    "Var[AX] & = Var(A)*(E(X))^2 + Var(X)*(E(A))^2 + Var(A)*Var(X) & (\\text{A and X are independent}) \\\\\n",
+    " & = Var(A) * Var(X)\\\\\n",
+    " & = 1\n",
     "\\end{align}\n",
     "$"
    ]
@@ -535,7 +538,7 @@
     {
      "data": {
       "text/plain": [
-       "(-0.3848510993003845, 505.62580416496115)"
+       "(0.20422200517654418, tensor(513.3586))"
       ]
      },
      "execution_count": null,
@@ -544,38 +547,45 @@
     }
    ],
    "source": [
-    "mean, var = 0., 0.\n",
+    "mean, var = 0.0, 0.0\n",
     "n_iter = 10000\n",
     "n_dim = 512\n",
+    "ys = []\n",
     "for i in range(n_iter):\n",
     "    x = torch.randn(n_dim)\n",
     "    a = torch.randn(n_dim) #just like one row of a\n",
-    "    y = a @x\n",
+    "    y = a@x\n",
     "    mean += y.item()\n",
-    "    var  += y.pow(2).item()\n",
-    "    \n",
-    "mean/n_iter, var/n_iter"
+    "    ys.append(y.item())\n",
+    "mean/n_iter, torch.tensor(ys).var()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we sum 512 of those things that have a mean of zero, and a mean of squares of 512, so we get something that has a mean of 0, and mean of square of 512. If we scale the weights of the matrix a and divide them by this math.sqrt(512), we will be picking elements of a from a distribution with 0 mean and variance = $1 / 512$. This will in turn give us a distribution of y in which each element has 0 mean and std = 1, thus allowing us to repeat the product has many times as we want won't overflow or vanish. The proof and the experiments follow."
+    "So how do we fix this situation? If we scale the weights of the matrix $a$ and divide them by this $math.sqrt(512)$, we will be picking elements of a from a distribution with $0$ mean and variance = $1 / 512$. This will in turn give us a distribution of $y$ in which each element has 0 mean and std = 1, thus allowing us to repeat the product has many times as we want. The proof and the experiments follow."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Proof that Y is now $\\sim U(0, 1)$"
+    "### Proof that Y is $\\sim U(0, 1)$  when A $\\sim U(0, 1 / \\sqrt{512})$ "
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "After the normalization, when we create $A$, instead of sampling from $U(0, 1)$, we sample from $U(0, 1 / \\sqrt(512))$. This is the case since we divide every element of $a$ by $1/sqrt(512)$. We will now prove that this leads to $Y$ getting a better distribution. We will stick to our example of 512."
+    "After the normalization, we start sampling the elements of $a$ from a different distribution. Instead of sampling from $U(0, 1)$, we sample from $U(0, 1 / \\sqrt{512})$. This is the case since we divide every element of $a$ by $1/\\sqrt{512}$. We will now prove that this leads to $Y$ getting a better distribution. We will continue with the running example of 512."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have"
    ]
   },
   {
@@ -665,18 +675,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(0.006510300114750862, 1.0147866140232764)"
+       "(-0.004015670036152005, tensor(1.0114))"
       ]
      },
      "execution_count": null,
@@ -685,17 +688,17 @@
     }
    ],
    "source": [
-    "mean, var = 0., 0.\n",
+    "mean, var = 0.0, 0.0\n",
     "n_iter = 10000\n",
     "n_dim = 512\n",
+    "ys = []\n",
     "for i in range(n_iter):\n",
     "    x = torch.randn(n_dim)\n",
-    "    a = torch.randn(n_dim) / math.sqrt(dim) #just like one row of a\n",
-    "    y = a @x\n",
+    "    a = torch.randn(n_dim) / math.sqrt(n_dim) #just like one row of a\n",
+    "    y = a@x\n",
     "    mean += y.item()\n",
-    "    var  += y.pow(2).item()\n",
-    "    \n",
-    "mean/n_iter, var/n_iter"
+    "    ys.append(y.item())\n",
+    "mean/n_iter, torch.tensor(ys).var()"
    ]
   },
   {
@@ -713,7 +716,7 @@
     {
      "data": {
       "text/plain": [
-       "(0.003834125765133649, 0.9961219137907028)"
+       "(-0.0015018963534384965, 1.006529658436775)"
       ]
      },
      "execution_count": null,
@@ -753,7 +756,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can reproduce the previous experiment with a ReLU, to see that this time, the mean shifts and the standard deviation becomes 0.5. This time the magic number will be `math.sqrt(2/512)` to properly scale the weights of the matrix."
+    "We can reproduce the previous experiments with a ReLU, to see that this time, the mean shifts (since we only keep the positive integers) and the standard deviation becomes closer to half of the earlier 512 (again, intuitively we're only sampling from the positive half of the distribution). This time the magic number will be `math.sqrt(2/512)` to properly scale the weights of the matrix. This fix comes from Kaiming initialization."
    ]
   },
   {
@@ -764,7 +767,7 @@
     {
      "data": {
       "text/plain": [
-       "(0.313308998029304, 0.4902977162997965)"
+       "(tensor(8.8806), tensor(171.9054))"
       ]
      },
      "execution_count": null,
@@ -773,15 +776,19 @@
     }
    ],
    "source": [
-    "mean,sqr = 0.,0.\n",
+    "mean, var = 0., 0.\n",
+    "ys = []\n",
+    "n_iter = 10000\n",
+    "n_dim = 512\n",
     "for i in range(10000):\n",
-    "    x = torch.randn(1)\n",
-    "    a = torch.randn(1)\n",
-    "    y = a*x\n",
-    "    y = 0 if y < 0 else y.item()\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim)\n",
+    "    y = a@x\n",
+    "    y = y if y > 0 else 0\n",
     "    mean += y\n",
-    "    sqr  += y ** 2\n",
-    "mean/10000,sqr/10000"
+    "    ys.append(y)\n",
+    "    \n",
+    "mean/n_iter, torch.tensor(ys).var()"
    ]
   },
   {
@@ -799,7 +806,7 @@
     {
      "data": {
       "text/plain": [
-       "(9.005213165283203, 257.3701454162598)"
+       "(8.999099245071411, 173.66994293212892)"
       ]
      },
      "execution_count": null,
@@ -808,22 +815,24 @@
     }
    ],
    "source": [
-    "mean,sqr = 0.,0.\n",
-    "for i in range(100):\n",
-    "    x = torch.randn(512)\n",
-    "    a = torch.randn(512, 512)\n",
+    "mean, var = 0., 0.\n",
+    "n_dim = 512\n",
+    "n_iter = 100\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim, n_dim)\n",
     "    y = a @ x\n",
     "    y = y.clamp(min=0)\n",
     "    mean += y.mean().item()\n",
-    "    sqr  += y.pow(2).mean().item()\n",
-    "mean/100,sqr/100"
+    "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "mean/n_iter, var/n_iter"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Or that scaling the coefficient with the magic number gives us a scale of 1."
+    "Or that scaling the coefficient with the magic number gets us closer to 1. Playing around with $magic\\_no\\_coeff$ shows that $\\sqrt{3 / 512}$ gets us closer to 1."
    ]
   },
   {
@@ -834,7 +843,7 @@
     {
      "data": {
       "text/plain": [
-       "(0.5643280637264252, 1.0055165421962737)"
+       "(0.5574615892767906, 0.6639472490549088)"
       ]
      },
      "execution_count": null,
@@ -843,23 +852,33 @@
     }
    ],
    "source": [
-    "mean,sqr = 0.,0.\n",
-    "for i in range(100):\n",
-    "    x = torch.randn(512)\n",
-    "    a = torch.randn(512, 512) * math.sqrt(2/512)\n",
+    "mean, var = 0., 0.\n",
+    "n_dim = 512\n",
+    "n_iter = 100\n",
+    "magic_no_coeff = 2\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim, n_dim) * (math.sqrt(magic_no_coeff / n_dim))\n",
     "    y = a @ x\n",
     "    y = y.clamp(min=0)\n",
     "    mean += y.mean().item()\n",
-    "    sqr  += y.pow(2).mean().item()\n",
-    "mean/100,sqr/100"
+    "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "mean/n_iter, var/n_iter"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The math behind is a tiny bit more complex, and you can find everything in the [Kaiming](https://arxiv.org/abs/1502.01852) and the [Xavier](http://proceedings.mlr.press/v9/glorot10a.html) paper but this gives the intuition behing those results."
+    "The math behind is a tiny bit more complex, and you can find everything in the [Kaiming](https://arxiv.org/abs/1502.01852) and the [Xavier](http://proceedings.mlr.press/v9/glorot10a.html) papers."
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/dev_course/dl2/02b_initializing.ipynb
+++ b/dev_course/dl2/02b_initializing.ipynb
@@ -6,15 +6,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import torch\n",
-    "import math"
+    "import torch"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Why you need a good init"
+    "### Why you need a good init?"
    ]
   },
   {
@@ -217,7 +216,7 @@
     {
      "data": {
       "text/plain": [
-       "(tensor(0.0144), tensor(0.5380))"
+       "(tensor(0.0429), tensor(0.9888))"
       ]
      },
      "execution_count": null,
@@ -280,7 +279,7 @@
     {
      "data": {
       "text/plain": [
-       "(tensor(0.0188), tensor(0.9201))"
+       "(tensor(-0.0051), tensor(0.9912))"
       ]
      },
      "execution_count": null,
@@ -299,14 +298,25 @@
    "source": [
     "NB: This is why it's extremely important to normalize your inputs in Deep Learning, the intialization rules have been designed with inputs that have a mean 0. and a standard deviation of 1.\n",
     "\n",
-    "If you need a refresher from your statistics course, the mean is the sum of all the elements divided by the number of elements (a basic average). The variance of a dataset gives a measure of whether the data stays close to the mean or generally has values that are far away from the mean. In other words, variance gives a measure of the spread of the data. It's computed by the following formula:\n",
+    "If you need a refresher from your statistics course, the mean is the sum of all the elements divided by the number of elements (a basic average). The variance of a dataset gives a measure of whether the data stays close to the mean or has values that are far away from the mean. In other words, variance gives a measure of the spread of the data. It's computed by the following formula:\n",
     "\n",
     "$$\\sigma^2 = \\frac{1}{n}\\left[(x_{0}-m)^{2} + (x_{1}-m)^{2} + \\cdots + (x_{n-1}-m)^{2}\\right]$$\n",
     "\n",
     "\n",
-    "where m is the mean and $\\sigma^2$ (the greek letter sigma) is the variance. The square root of the variance is called standard deviation ($\\sigma$). Clearly, $\\sigma$ and $\\sigma^2$ directly depend on each other. Thus, changing one leads to a change in the other. \n",
+    "where m is the mean and $\\sigma^2$ (the greek letter sigma squared) is the variance. \n",
+    "\n",
+    "The square root of the variance is called standard deviation ($\\sigma$). Clearly, $\\sigma$ and $\\sigma^2$ directly depend on each other. Thus, changing one leads to a change in the other. \n",
     "\n",
     "If we go back to `y = a @ x` and assume that we chose weights for `a` that also have a mean of 0, we can compute the variance of `y` quite easily. Since it's random, and we may fall on bad numbers, we repeat the operation 100 times."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note on variance vs. standard deviation**\n",
+    "\n",
+    "Please don't let the differences in the variance and the standard deviation scare you. Variance is **exactly** the square of the standard deviation. We use both for the experiments. Variance makes more sense when you want to reason about things and the proofs, and standard deviation makes more sense when thinking about normalization. "
    ]
   },
   {
@@ -317,7 +327,7 @@
     {
      "data": {
       "text/plain": [
-       "(-0.020908803418278693, 505.53545623779297)"
+       "(-0.0318191758915782, 510.5513998413086, 22.572354526519774)"
       ]
      },
      "execution_count": null,
@@ -326,7 +336,7 @@
     }
    ],
    "source": [
-    "mean, var = 0., 0.\n",
+    "mean, var, std = 0., 0., 0.0\n",
     "n_dim = 512\n",
     "n_iter = 100\n",
     "for i in range(n_iter):\n",
@@ -334,16 +344,17 @@
     "    a = torch.randn(n_dim, n_dim)\n",
     "    y = a @ x\n",
     "    mean += y.mean().item()\n",
-    "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "    var += (y - y.mean()).pow(2).mean().item()\n",
+    "    std += (y - y.mean()).pow(2).mean().sqrt().item()\n",
     "    \n",
-    "mean/n_iter, var/n_iter"
+    "mean/n_iter, var/n_iter, std/n_iter"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that looks very close to the dimension of our matrix 512. And that's no coincidence! When you compute y, you sum 512 product of one element of a by one element of x. So what's the mean and the variance of such a product? We can show mathematically that as long as the elements in a and the elements in x are independent, the mean is 0 and the variance is 512. This can also be seen experimentally:"
+    "Now the variance looks very close to the dimension of our matrix 512! (the standard deviation is just the square root of the variance). And that's no coincidence! When you compute y, you sum 512 product of one element of a by one element of x. So what's the mean and the variance of such a product? We can show mathematically that as long as the elements in a and the elements in x are independent, the mean is 0 and the variance is 512. (Please see the end of this notebook for the proof). This can also be seen experimentally:"
    ]
   },
   {
@@ -354,7 +365,7 @@
     {
      "data": {
       "text/plain": [
-       "(0.08155614581108094, tensor(512.1214))"
+       "(-0.13198307995796205, tensor(513.4638), tensor(22.6597))"
       ]
      },
      "execution_count": null,
@@ -373,14 +384,242 @@
     "    y = a@x\n",
     "    mean += y.item()\n",
     "    ys.append(y.item())\n",
-    "mean/n_iter, torch.tensor(ys).var()"
+    "mean/n_iter, torch.tensor(ys).var(), torch.tensor(ys).std()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Proof that $Y \\sim U(0, 512)$"
+    "In other words, each element of y is picked from an erratic distribution, and that's happening because of the way it is calculated. Intuitively, we are taking numbers from a and x and multiplying them together. What if we reduce the magnitude of the a terms before multiplying?\n",
+    "\n",
+    "If we scale the weights of the matrix $a$ and divide them by this $math.sqrt(512)$, we will be picking elements of a from a distribution with $0$ mean and variance = $1 / 512$. This will in turn give us a distribution of $y$ in which each element has 0 mean and std = 1, thus allowing us to repeat the product has many times as we want. Let's check if this holds:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-0.00671036799326539, tensor(1.0186), tensor(1.0092))"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mean, var = 0.0, 0.0\n",
+    "n_iter = 10000\n",
+    "n_dim = 512\n",
+    "ys = []\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim) / math.sqrt(n_dim) #just like one row of a\n",
+    "    y = a@x\n",
+    "    mean += y.item()\n",
+    "    ys.append(y.item())\n",
+    "mean/n_iter, torch.tensor(ys).var(), torch.tensor(ys).std() "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Works! Back to our original problem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.004124592710286379, 1.008240037560463, 1.0033940666913985)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mean, var, std = 0., 0., 0.0\n",
+    "n_dim = 512\n",
+    "n_iter = 100\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim, n_dim) / math.sqrt(n_dim)\n",
+    "    y = a @ x\n",
+    "    mean += y.mean().item()\n",
+    "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "    std  += (y - y.mean()).pow(2).mean().sqrt().item()\n",
+    "    \n",
+    "mean/n_iter, var/n_iter, std/n_iter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Makes sense!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding ReLU in the mix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can reproduce the previous experiments with a ReLU, to see that this time, the mean shifts (since we only keep the positive integers) and the standard deviation becomes closer to half of the earlier 512 (again, intuitively we're only sampling from the positive half of the distribution). This time the magic number will be `math.sqrt(2/512)` to properly scale the weights of the matrix. This fix comes from Kaiming initialization."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(tensor(8.8724), tensor(173.2703), tensor(13.1632))"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mean, var = 0., 0.\n",
+    "ys = []\n",
+    "n_iter = 10000\n",
+    "n_dim = 512\n",
+    "for i in range(10000):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim)\n",
+    "    y = a@x\n",
+    "    y = y if y > 0 else 0\n",
+    "    mean += y\n",
+    "    ys.append(y)\n",
+    "    \n",
+    "mean/n_iter, torch.tensor(ys).var(), torch.tensor(ys).std()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can double check by running the experiment on the whole matrix product."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(9.045812311172485, 173.1652326965332, 13.141505727767944)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mean, var, std = 0., 0., 0.\n",
+    "n_dim = 512\n",
+    "n_iter = 100\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim, n_dim)\n",
+    "    y = a @ x\n",
+    "    y = y.clamp(min=0)\n",
+    "    mean += y.mean().item()\n",
+    "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "    std  += (y - y.mean()).pow(2).mean().sqrt().item()\n",
+    "mean/n_iter, var/n_iter, std/n_iter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or that scaling the coefficient with the magic number gets us closer to 1. Playing around with $magic\\_no\\_coeff$ shows that $\\sqrt{3 / 512}$ gets us closer to 1."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.5626724684238433, 0.6809485444426536, 0.8240003716945649)"
+      ]
+     },
+     "execution_count": null,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mean, var, std = 0., 0., 0.\n",
+    "n_dim = 512\n",
+    "n_iter = 100\n",
+    "magic_no_coeff = 2\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim, n_dim) * (math.sqrt(magic_no_coeff / n_dim))\n",
+    "    y = a @ x\n",
+    "    y = y.clamp(min=0)\n",
+    "    mean += y.mean().item()\n",
+    "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "    std  += (y - y.mean()).pow(2).mean().sqrt().item()\n",
+    "mean/n_iter, var/n_iter, std/n_iter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The math behind is a tiny bit more complex, and the proofs in the appendix are a good starting point. You can find everything in the [Kaiming](https://arxiv.org/abs/1502.01852) and the [Xavier](http://proceedings.mlr.press/v9/glorot10a.html) papers."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<hr>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Appendix"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Proof that $Y \\sim U(0, 512)$"
    ]
   },
   {
@@ -538,7 +777,7 @@
     {
      "data": {
       "text/plain": [
-       "(0.20422200517654418, tensor(513.3586))"
+       "(-0.10872242888212204, tensor(514.2963))"
       ]
      },
      "execution_count": null,
@@ -571,7 +810,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Proof that Y is $\\sim U(0, 1)$  when A $\\sim U(0, 1 / \\sqrt{512})$ "
+    "## Proof that Y is $\\sim U(0, 1)$  when A $\\sim U(0, 1 / \\sqrt{512})$ "
    ]
   },
   {
@@ -679,7 +918,7 @@
     {
      "data": {
       "text/plain": [
-       "(-0.004015670036152005, tensor(1.0114))"
+       "(-0.008042885749042035, tensor(0.9856), tensor(0.9928))"
       ]
      },
      "execution_count": null,
@@ -698,7 +937,7 @@
     "    y = a@x\n",
     "    mean += y.item()\n",
     "    ys.append(y.item())\n",
-    "mean/n_iter, torch.tensor(ys).var()"
+    "mean/n_iter, torch.tensor(ys).var(), torch.tensor(ys).std() "
    ]
   },
   {
@@ -716,7 +955,7 @@
     {
      "data": {
       "text/plain": [
-       "(-0.0015018963534384965, 1.006529658436775)"
+       "(-0.0005847464455291629, 1.0092255067825318, 1.0035727471113205)"
       ]
      },
      "execution_count": null,
@@ -725,7 +964,7 @@
     }
    ],
    "source": [
-    "mean, var = 0., 0.\n",
+    "mean, var, std = 0., 0., 0.0\n",
     "n_dim = 512\n",
     "n_iter = 100\n",
     "for i in range(n_iter):\n",
@@ -734,151 +973,10 @@
     "    y = a @ x\n",
     "    mean += y.mean().item()\n",
     "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "    std  += (y - y.mean()).pow(2).mean().sqrt().item()\n",
     "    \n",
-    "mean/n_iter, var/n_iter"
+    "mean/n_iter, var/n_iter, std/n_iter"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Makes sense!"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Adding ReLU in the mix"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can reproduce the previous experiments with a ReLU, to see that this time, the mean shifts (since we only keep the positive integers) and the standard deviation becomes closer to half of the earlier 512 (again, intuitively we're only sampling from the positive half of the distribution). This time the magic number will be `math.sqrt(2/512)` to properly scale the weights of the matrix. This fix comes from Kaiming initialization."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(tensor(8.8806), tensor(171.9054))"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mean, var = 0., 0.\n",
-    "ys = []\n",
-    "n_iter = 10000\n",
-    "n_dim = 512\n",
-    "for i in range(10000):\n",
-    "    x = torch.randn(n_dim)\n",
-    "    a = torch.randn(n_dim)\n",
-    "    y = a@x\n",
-    "    y = y if y > 0 else 0\n",
-    "    mean += y\n",
-    "    ys.append(y)\n",
-    "    \n",
-    "mean/n_iter, torch.tensor(ys).var()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We can double check by running the experiment on the whole matrix product."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(8.999099245071411, 173.66994293212892)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mean, var = 0., 0.\n",
-    "n_dim = 512\n",
-    "n_iter = 100\n",
-    "for i in range(n_iter):\n",
-    "    x = torch.randn(n_dim)\n",
-    "    a = torch.randn(n_dim, n_dim)\n",
-    "    y = a @ x\n",
-    "    y = y.clamp(min=0)\n",
-    "    mean += y.mean().item()\n",
-    "    var  += (y - y.mean()).pow(2).mean().item()\n",
-    "mean/n_iter, var/n_iter"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Or that scaling the coefficient with the magic number gets us closer to 1. Playing around with $magic\\_no\\_coeff$ shows that $\\sqrt{3 / 512}$ gets us closer to 1."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(0.5574615892767906, 0.6639472490549088)"
-      ]
-     },
-     "execution_count": null,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "mean, var = 0., 0.\n",
-    "n_dim = 512\n",
-    "n_iter = 100\n",
-    "magic_no_coeff = 2\n",
-    "for i in range(n_iter):\n",
-    "    x = torch.randn(n_dim)\n",
-    "    a = torch.randn(n_dim, n_dim) * (math.sqrt(magic_no_coeff / n_dim))\n",
-    "    y = a @ x\n",
-    "    y = y.clamp(min=0)\n",
-    "    mean += y.mean().item()\n",
-    "    var  += (y - y.mean()).pow(2).mean().item()\n",
-    "mean/n_iter, var/n_iter"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The math behind is a tiny bit more complex, and you can find everything in the [Kaiming](https://arxiv.org/abs/1502.01852) and the [Xavier](http://proceedings.mlr.press/v9/glorot10a.html) papers."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/dev_course/dl2/02b_initializing.ipynb
+++ b/dev_course/dl2/02b_initializing.ipynb
@@ -2,11 +2,12 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [],
    "source": [
-    "import torch"
+    "import torch\n",
+    "import math"
    ]
   },
   {
@@ -25,7 +26,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -35,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -44,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -53,7 +54,7 @@
        "(tensor(nan), tensor(nan))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -71,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -81,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -92,16 +93,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 41,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "28"
+       "27"
       ]
      },
-     "execution_count": null,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -119,7 +120,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [
     {
@@ -147,7 +148,7 @@
        "(tensor(0.), tensor(0.))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 44,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -182,7 +183,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -201,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,16 +211,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(tensor(-0.0171), tensor(0.9270))"
+       "(tensor(0.0982), tensor(4.2881))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 48,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -237,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -246,7 +247,7 @@
        "0.044194173824159216"
       ]
      },
-     "execution_count": null,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -273,16 +274,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(tensor(0.0144), tensor(1.0207))"
+       "(tensor(-0.0648), tensor(0.9609))"
       ]
      },
-     "execution_count": null,
+     "execution_count": 50,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -298,71 +299,76 @@
    "source": [
     "NB: This is why it's extremely important to normalize your inputs in Deep Learning, the intialization rules have been designed with inputs that have a mean 0. and a standard deviation of 1.\n",
     "\n",
-    "If you need a refresher from your statistics course, the mean is the sum of all the elements divided by the number of elements (a basic average). The standard deviation represents if the data stays close to the mean or on the contrary gets values that are far away. It's computed by the following formula:\n",
+    "If you need a refresher from your statistics course, the mean is the sum of all the elements divided by the number of elements (a basic average). The variance of a dataset gives a measure of whether the data stays close to the mean or generally has values that are far away from the mean. In other words, variance gives a measure of the spread of the data. It's computed by the following formula:\n",
     "\n",
-    "$$\\sigma = \\sqrt{\\frac{1}{n}\\left[(x_{0}-m)^{2} + (x_{1}-m)^{2} + \\cdots + (x_{n-1}-m)^{2}\\right]}$$\n",
+    "$$\\sigma^2 = \\frac{1}{n}\\left[(x_{0}-m)^{2} + (x_{1}-m)^{2} + \\cdots + (x_{n-1}-m)^{2}\\right]$$\n",
     "\n",
-    "where m is the mean and $\\sigma$ (the greek letter sigma) is the standard deviation. Here we have a mean of 0, so it's just the square root of the mean of x squared.\n",
     "\n",
-    "If we go back to `y = a @ x` and assume that we chose weights for `a` that also have a mean of 0, we can compute the standard deviation of `y` quite easily. Since it's random, and we may fall on bad numbers, we repeat the operation 100 times."
+    "where m is the mean and $\\sigma^2$ (the greek letter sigma) is the variance. The square root of the variance is called standard deviation ($\\sigma$). Clearly, $\\sigma$ and $\\sigma^2$ directly depend on each other. Thus, changing one leads to a change in the other. \n",
+    "\n",
+    "If we go back to `y = a @ x` and assume that we chose weights for `a` that also have a mean of 0, we can compute the variance of `y` quite easily. Since it's random, and we may fall on bad numbers, we repeat the operation 100 times."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 52,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(0.01184942677617073, 516.7942666625977)"
+       "(-0.000560310110449791, 508.57024475097654)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 52,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "mean,sqr = 0.,0.\n",
-    "for i in range(100):\n",
-    "    x = torch.randn(512)\n",
-    "    a = torch.randn(512, 512)\n",
+    "mean, var = 0., 0.\n",
+    "n_dim = 512\n",
+    "n_iter = 100\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim, n_dim)\n",
     "    y = a @ x\n",
     "    mean += y.mean().item()\n",
-    "    sqr  += y.pow(2).mean().item()\n",
-    "mean/100,sqr/100"
+    "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "    \n",
+    "mean/n_iter, var/n_iter"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now that looks very close to the dimension of our matrix 512. And that's no coincidence! When you compute y, you sum 512 product of one element of a by one element of x. So what's the mean and the standard deviation of such a product? We can show mathematically that as long as the elements in `a` and the elements in `x` are independent, the mean is 0 and the std is 1. This can also be seen experimentally:"
+    "Now that looks very close to the dimension of our matrix 512. And that's no coincidence! When you compute y, you sum 512 product of one element of a by one element of x. So what's the mean and the variance of such a product? We can show mathematically that as long as the elements in a and the elements in x are independent, the mean is 0 and the variance is 512. This can also be seen experimentally:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 58,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "(0.013266791818584533, 0.9896199178691623)"
+       "(-0.351292731320858, 517.5591897146537)"
       ]
      },
-     "execution_count": null,
+     "execution_count": 58,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "mean,sqr = 0.,0.\n",
-    "for i in range(10000):\n",
-    "    x = torch.randn(1)\n",
-    "    a = torch.randn(1)\n",
-    "    y = a*x\n",
+    "n_iter = 10000\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(512)\n",
+    "    a = torch.randn(512) #just like one row of a\n",
+    "    y = a @x\n",
     "    mean += y.item()\n",
     "    sqr  += y.pow(2).item()\n",
     "mean/10000,sqr/10000"
@@ -372,7 +378,368 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we sum 512 of those things that have a mean of zero, and a mean of squares of 1, so we get something that has a mean of 0, and mean of square of 512, hence `math.sqrt(512)` being our magic number. If we scale the weights of the matrix `a` and divide them by this `math.sqrt(512)`, it will give us a `y` of scale 1, and repeating the product has many times as we want won't overflow or vanish."
+    "### Proof that $Y \\sim U(0, 512)$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are given that $x$ and $a$ are from a distribution with mean = 0 and variance = 1. That is, to create $x$, we pick 512 random numbers from a distribution with 0 mean and std 1. Similarly, to create $a$, we pick (512 * 512) random numbers from a distribution with mean 0 and std 1. Then $i^{th}$ element of $y$ is calculated by multiplying 512 elements of $a$ (i.e. $a[i]$) with 512 elements of $x$."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$$y_{i} = a_{i,0} x_{0} + a_{i,1} x_{1} + + a_{i,511} x_{511} = \\sum_{k=0}^{511} a_{i,k} x_{k}$$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let $A$ be the random variable from which $a$ is taken, and $X$ be the random variable from which $x$ is taken. Let $y$ be the random variable from which $Y$ is sampled.  We know that one element of $Y$ is created by multiplying 512 elements from $A$ and $X$ with each other. That is, we sample 512 elements from $A$, 512 elements from $X$ and multiply them with each other. Thus, so far we have:\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "& A \\sim U(0, 1) \\\\\n",
+    "& E \\sim U(0, 1) \\\\ \n",
+    "& E[A] = 0 \\\\\n",
+    "& E[X] = 0 \\\\ \n",
+    "& Var[A] = Std[A] = 1 \\\\ \n",
+    "& Var[X] = Std[X] = 1 \\\\ \n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "Y = \\sum_{k=0}^{511} A*X\n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's start by calculating the mean of Y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Expectation (Mean) of Y\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "E[Y] & = E[AX] \\\\\n",
+    "& = E[A] * E[X] = 0 \\ (\\because E[A] = E[X] = 0)\n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Variance of Y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's first calculate the variance of $AX$. That is, what would be the variance if we pick one element randomly from $A$ and $X$ and then multiply them?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "Var[AX] & = Var(A)*(E(X))^2 + Var(X)*(E(A))^2 + Var(A)*Var(X) \\\\\n",
+    " & = Var(A) * Var(X) = 1\n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We know that Y is formed by summing 512 such elements or"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "Y = \\sum_{k=0}^{511} A*X\n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Thus"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "Var[Y] & = Var[\\sum_{k=0}^{511}A * X] \\\\\n",
+    "    & = \\sum_{k=0}^{511} Var[AX] &(\\text{A and X are independent}) \\\\\n",
+    "& = \\sum_{k=0}^{511} 1  &(\\text{Var[AX] = 1 from above}) \\\\\\\\\n",
+    "& = 512\n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In other words, $Y \\sim U(0, 512)$ which is bad, since Y now varies a lot! The experiment is reproduced below for ready reference. *Each of the ys have a large variance!*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(-0.3848510993003845, 505.62580416496115)"
+      ]
+     },
+     "execution_count": 55,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mean, var = 0., 0.\n",
+    "n_iter = 10000\n",
+    "n_dim = 512\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim) #just like one row of a\n",
+    "    y = a @x\n",
+    "    mean += y.item()\n",
+    "    var  += y.pow(2).item()\n",
+    "    \n",
+    "mean/n_iter, var/n_iter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we sum 512 of those things that have a mean of zero, and a mean of squares of 512, so we get something that has a mean of 0, and mean of square of 512. If we scale the weights of the matrix a and divide them by this math.sqrt(512), we will be picking elements of a from a distribution with 0 mean and variance = $1 / 512$. This will in turn give us a distribution of y in which each element has 0 mean and std = 1, thus allowing us to repeat the product has many times as we want won't overflow or vanish. The proof and the experiments follow."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Proof that Y is now $\\sim U(0, 1)$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After the normalization, when we create $A$, instead of sampling from $U(0, 1)$, we sample from $U(0, 1 / \\sqrt(512))$. This is the case since we divide every element of $a$ by $1/sqrt(512)$. We will now prove that this leads to $Y$ getting a better distribution. We will stick to our example of 512."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "& A \\sim U(0, 1 / \\sqrt512) \\\\\n",
+    "& E \\sim U(0, 1) \\\\ \n",
+    "& E[A] = 0 \\\\\n",
+    "& E[X] = 0 \\\\ \n",
+    "& Var[A] = 1 / 512, Std[A] = 1 / \\sqrt(512) \\\\ \n",
+    "& Var[X] = Std[X] = 1 \\\\ \n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Expectation (Mean) of Y (unchanged)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "$\n",
+    "\\begin{align}\n",
+    "E[Y] & = E[AX] \\\\\n",
+    "& = E[A] * E[X] = 0 \\ (\\because E[A] = E[X] = 0)\n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Variance of Y"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As before, let's first calculate the variance of $AX$. That is, what would be the variance if we pick one element randomly from $A$ and $X$ and then multiply them?"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "Var[AX] & = Var(A)*(E(X))^2 + Var(X)*(E(A))^2 + Var(A)*Var(X) \\\\\n",
+    " & = Var(A) * Var(X) = 1 / 512\n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "$\n",
+    "\\begin{align}\n",
+    "Var[Y] & = Var[\\sum_{k=0}^{511}A * X] \\\\\n",
+    "    & = \\sum_{k=0}^{511} Var[AX] &(\\text{A and X are independent}) \\\\\n",
+    "& = \\sum_{k=0}^{511} 1 / 512  &(\\text{Var[AX] = 1 from above}) \\\\\\\\\n",
+    "& = 1\n",
+    "\\end{align}\n",
+    "$"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In other words, $Y \\sim U(0, 1)$ which is what we wanted! Let's do some quick experiments to make sure this holds:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 56,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.006510300114750862, 1.0147866140232764)"
+      ]
+     },
+     "execution_count": 56,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mean, var = 0., 0.\n",
+    "n_iter = 10000\n",
+    "n_dim = 512\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim) / math.sqrt(dim) #just like one row of a\n",
+    "    y = a @x\n",
+    "    mean += y.item()\n",
+    "    var  += y.pow(2).item()\n",
+    "    \n",
+    "mean/n_iter, var/n_iter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Works! Back to our original problem:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(0.003834125765133649, 0.9961219137907028)"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "mean, var = 0., 0.\n",
+    "n_dim = 512\n",
+    "n_iter = 100\n",
+    "for i in range(n_iter):\n",
+    "    x = torch.randn(n_dim)\n",
+    "    a = torch.randn(n_dim, n_dim) / math.sqrt(n_dim)\n",
+    "    y = a @ x\n",
+    "    mean += y.mean().item()\n",
+    "    var  += (y - y.mean()).pow(2).mean().item()\n",
+    "    \n",
+    "mean/n_iter, var/n_iter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Makes sense!"
    ]
   },
   {
@@ -500,6 +867,18 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Correct the references to "variance". The variance has been
referred to as standard deviation in several places.

2. The variance of the products of A[i] and X will be 512, not 1. (From: _We can show mathematically that as long as the elements in a and the elements in x are independent, the mean is 0 and the std is 1._). 

- The issue thus is that *each* element of y is now sampled from an erratic distribution, not just one element. In my opinion, this is one of the bigger points that the notebook currently misses. 

3. Add a note on how the normalization will fix point 2) above.

4. Add proofs (math + empirical) for points 2 and 3.
