### PR TITLE
update train_dl xb,yb for Pytorch DataLoader session

### DIFF
--- a/dev_course/dl2/03_minibatch_training.ipynb
+++ b/dev_course/dl2/03_minibatch_training.ipynb
@@ -1791,6 +1791,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "xb,yb = next(iter(train_dl))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -1824,6 +1833,15 @@
    "source": [
     "train_dl = DataLoader(train_ds, bs, shuffle=True, drop_last=True)\n",
     "valid_dl = DataLoader(valid_ds, bs, shuffle=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xb,yb = next(iter(train_dl))"
    ]
   },
   {


### PR DESCRIPTION
In 'Pytorch DataLoader' session, new DataLoader class and objects are defined but loss and accuracy are calculated based on train batch from previous DataLoader, which is xb (e.g loss_func(model(xb), yb), accuracy(model(xb), yb)). I figure this won't affect the outputs at all since these data loaders are the same, but still...