### PR TITLE
Add Swift translation of conv init notebook

### DIFF
--- a/dev_swift/02a_why_sqrt5.ipynb
+++ b/dev_swift/02a_why_sqrt5.ipynb
@@ -1,0 +1,1135 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "name": "02a_why_sqrt5.ipynb",
+      "version": "0.3.2",
+      "provenance": [],
+      "toc_visible": true
+    },
+    "kernelspec": {
+      "name": "swift",
+      "display_name": "Swift"
+    }
+  },
+  "cells": [
+    {
+      "metadata": {
+        "id": "Yi7RWDohafcd",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "// %install '.package(path: \"https://github.com/fastai/fastai_docs/dev_swift/FastaiNotebooks\")' FastaiNotebooks"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "eTDNyXtgW4h9",
+        "colab_type": "code",
+        "outputId": "a03b5dcf-f145-4192-bf4b-08428198268a",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 493
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "%install '.package(url: \"https://github.com/mxcl/Path.swift\", from: \"0.16.1\")' Path\n",
+        "%install '.package(url: \"https://github.com/JustHTTP/Just\", from: \"0.7.1\")' Just\n",
+        "%install '.package(url: \"https://github.com/1024jp/GzipSwift\", from: \"4.1.0\")' Gzip"
+      ],
+      "execution_count": 1,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Installing packages:\n",
+            "\t.package(url: \"https://github.com/mxcl/Path.swift\", from: \"0.16.1\")\n",
+            "\t\tPath\n",
+            "\t.package(url: \"https://github.com/JustHTTP/Just\", from: \"0.7.1\")\n",
+            "\t\tJust\n",
+            "\t.package(url: \"https://github.com/1024jp/GzipSwift\", from: \"4.1.0\")\n",
+            "\t\tGzip\n",
+            "With SwiftPM flags: []\n",
+            "Working in: /tmp/tmpd5at4ask\n",
+            "Fetching https://github.com/mxcl/Path.swift\n",
+            "Fetching https://github.com/JustHTTP/Just\n",
+            "Fetching https://github.com/1024jp/GzipSwift\n",
+            "Completed resolution in 2.16s\n",
+            "Cloning https://github.com/JustHTTP/Just\n",
+            "Resolving https://github.com/JustHTTP/Just at 0.7.1\n",
+            "Cloning https://github.com/mxcl/Path.swift\n",
+            "Resolving https://github.com/mxcl/Path.swift at 0.16.2\n",
+            "Cloning https://github.com/1024jp/GzipSwift\n",
+            "Resolving https://github.com/1024jp/GzipSwift at 4.1.0\n",
+            "Compile system-zlib anchor.c\n",
+            "Compile Swift Module 'Just' (1 sources)\n",
+            "Compile Swift Module 'Path' (9 sources)\n",
+            "Compile Swift Module 'Gzip' (1 sources)\n",
+            "Compile Swift Module 'jupyterInstalledPackages' (1 sources)\n",
+            "Linking ./.build/x86_64-unknown-linux/debug/libjupyterInstalledPackages.so\n",
+            "Initializing Swift...\n",
+            "Loading library...\n",
+            "Installation complete!\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "pHv4cCe0W747",
+        "colab_type": "code",
+        "outputId": "c8347959-aa62-4f49-dc5b-88b0596e58ef",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 51
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "import Foundation\n",
+        "import TensorFlow\n",
+        "import Just\n",
+        "import Gzip\n",
+        "import Path\n",
+        "import Python\n",
+        "print(Python.version)"
+      ],
+      "execution_count": 2,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "3.6.7 (default, Oct 22 2018, 11:32:17) \r\n",
+            "[GCC 8.2.0]\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "-asBokKNX4IW",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "func loadMNIST(training: Bool, labels: Bool) -> Tensor<Float> {\n",
+        "    let split = training ? \"train\" : \"t10k\"\n",
+        "    let kind = labels ? \"labels\" : \"images\"\n",
+        "    let batch = training ? Int32(60000) : Int32(10000)\n",
+        "    let shape: TensorShape = labels ? [batch] : [batch, 28, 28]\n",
+        "    let rank = shape.rank\n",
+        "    let dropK = labels ? 8 : 16\n",
+        "    let gzipped = Just.get(\"http://yann.lecun.com/exdb/mnist/\" + split +\n",
+        "                         \"-\" + kind + \"-idx\\(rank)-ubyte.gz\").content!\n",
+        "    let data = try! gzipped.gunzipped().dropFirst(dropK)\n",
+        "    return Tensor(data.map {Float($0) / Float(255.0)}).reshaped(to: shape)\n",
+        "}\n",
+        "\n",
+        "func loadMNIST() -> (\n",
+        "    Tensor<Float>,\n",
+        "    Tensor<Float>,\n",
+        "    Tensor<Float>,\n",
+        "    Tensor<Float>\n",
+        ") {\n",
+        "    return (\n",
+        "        loadMNIST(training: true, labels: false),\n",
+        "        loadMNIST(training: true, labels: true),\n",
+        "        loadMNIST(training: false, labels: false),\n",
+        "        loadMNIST(training: false, labels: true)\n",
+        "    )\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "DZW71ftoQ4l_",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Does nn.Conv2d init work well?"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "g6SMuCDzQ4mA",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "extension Tensor where Scalar: TensorFlowFloatingPoint {\n",
+        "    func normalized(mean: Tensor, std: Tensor) -> Tensor {\n",
+        "        return (self - mean) / std\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "WtgV4cWYj4JP",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "// TODO: upstream this\n",
+        "extension Tensor where Scalar: TensorFlowFloatingPoint {\n",
+        "    func variance() -> Tensor {\n",
+        "        let axes = Array<Int32>(0..<rank)\n",
+        "        return variance(alongAxes: axes).squeezingShape(at: axes)\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "I1C-UtEqQ4mD",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "var (trainX, trainY, testX, testY) = loadMNIST()\n",
+        "let (trainX_mean, trainX_std) = (trainX.mean(), sqrt(trainX.variance()))\n",
+        "trainX = trainX.normalized(mean: trainX_mean, std: trainX_std)\n",
+        "testX = testX.normalized(mean: trainX_mean, std: trainX_std)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "w2bTYSWuQ4mI",
+        "colab_type": "code",
+        "outputId": "901cd563-4993-4405-95d4-3a161d58b58b",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "trainX = trainX.reshaped(to: [trainX.shape[0], 28, 28, 1])\n",
+        "testX = testX.reshaped(to: [testX.shape[0], 28, 28, 1])\n",
+        "print(trainX.shape, testX.shape)"
+      ],
+      "execution_count": 7,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "TensorShape(dimensions: [60000, 28, 28, 1]) TensorShape(dimensions: [10000, 28, 28, 1])\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "mRXX_CzAQ4mN",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "let images = trainX.shape[0]\n",
+        "let classes = trainY.max() + 1\n",
+        "let channels = 32"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "M51gGn8lQ4mR",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "var layer1 = Conv2D<Float>(filterShape: (5, 5, 1, channels)) //Conv2D(1, nh, 5)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "t6TbYz-dQ4mU",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "let x = testX[0..<100]"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "fZ055k4pQ4mW",
+        "colab_type": "code",
+        "outputId": "ae02d7a0-e19a-4502-f41e-fabfee0de67a",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 119
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "x.shape"
+      ],
+      "execution_count": 11,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ TensorShape\n",
+              "  ▿ dimensions : 4 elements\n",
+              "    - 0 : 100\n",
+              "    - 1 : 28\n",
+              "    - 2 : 28\n",
+              "    - 3 : 1\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 11
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "y0swgEeBQ4mb",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "extension Tensor where Scalar: TensorFlowFloatingPoint {\n",
+        "    func stats() -> (mean: Tensor, std: Tensor) {\n",
+        "        return (mean: self.mean(), std: sqrt(self.variance()))\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "_PPRDYGRQ4mg",
+        "colab_type": "code",
+        "outputId": "dcfcc77c-ea33-4ea7-94ad-b3bb60c92c28",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 136
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "(filter: layer1.filter.stats(), bias: layer1.bias.stats())"
+      ],
+      "execution_count": 13,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  ▿ filter : 2 elements\n",
+              "    - mean : 0.0013559912\n",
+              "    - std : 0.048515525\n",
+              "  ▿ bias : 2 elements\n",
+              "    - mean : 0.0\n",
+              "    - std : 0.0\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 13
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "vHUALQ0QQ4ml",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "let result = layer1.applied(to: x)"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "iqHilJjqQ4mn",
+        "colab_type": "code",
+        "outputId": "0b56fa31-8093-4948-99fa-3d91a6a9e891",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "result.stats()"
+      ],
+      "execution_count": 15,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  - mean : 0.0030350306\n",
+              "  - std : 0.27894023\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 15
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "Gs6Ql3VOR-6h",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "extension Tensor where Scalar: TensorFlowFloatingPoint {\n",
+        "    init(kaimingNormal shape: TensorShape, negativeSlope: Double = 1.0) {\n",
+        "        // Assumes Leaky ReLU nonlinearity\n",
+        "        let gain = Scalar(sqrt(2.0 / (1.0 + pow(negativeSlope, 2))))\n",
+        "        let spatialDimCount = shape.count - 2\n",
+        "        let receptiveField = shape[0..<spatialDimCount].contiguousSize\n",
+        "        let fanIn = shape[shape.count - 2] * receptiveField\n",
+        "        self.init(\n",
+        "            randomNormal: shape,\n",
+        "            stddev: gain / sqrt(Scalar(fanIn)),\n",
+        "            generator: &PhiloxRandomNumberGenerator.global\n",
+        "        )\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "GG2HD-x2Q4mr",
+        "colab_type": "code",
+        "outputId": "e1808a67-233e-4e6b-856e-39e3482b938b",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "layer1.filter = Tensor(kaimingNormal: layer1.filter.shape, negativeSlope: 1.0)\n",
+        "layer1.applied(to: x).stats()"
+      ],
+      "execution_count": 17,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  - mean : -0.009885282\n",
+              "  - std : 1.0364686\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 17
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "wax1qvcbQ4mw",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "func leakyRelu<T: TensorFlowFloatingPoint>(\n",
+        "    _ x: Tensor<T>,\n",
+        "    negativeSlope: Double = 0.0\n",
+        ") -> Tensor<T> {\n",
+        "    return max(0, x) + T(negativeSlope) * min(0, x)\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "KihjM2PAQ4m2",
+        "colab_type": "code",
+        "outputId": "95d2a24e-955a-4f62-9434-4d05b6e7d0f6",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "layer1.filter = Tensor(kaimingNormal: layer1.filter.shape, negativeSlope: 0.0)\n",
+        "leakyRelu(layer1.applied(to: x)).stats()"
+      ],
+      "execution_count": 19,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  - mean : 0.54207695\n",
+              "  - std : 1.0349665\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 19
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "Y0BbyDnxQ4m5",
+        "colab_type": "code",
+        "outputId": "0d5d5633-4f06-42ed-c5ab-170bfffc0fe6",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "var layer1 = Conv2D<Float>(filterShape: (5, 5, 1, channels)) //Conv2D(1, nh, 5)\n",
+        "leakyRelu(layer1.applied(to: x)).stats()"
+      ],
+      "execution_count": 20,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  - mean : 0.0999834\n",
+              "  - std : 0.1932733\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 20
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "-cmudAsfQ4m8",
+        "colab_type": "code",
+        "outputId": "4094e2e9-7948-4308-dba2-9bdbfe45d6a0",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 119
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "layer1.filter.shape"
+      ],
+      "execution_count": 21,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ TensorShape\n",
+              "  ▿ dimensions : 4 elements\n",
+              "    - 0 : 5\n",
+              "    - 1 : 5\n",
+              "    - 2 : 1\n",
+              "    - 3 : 32\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 21
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "xP7pqzFAQ4nA",
+        "colab_type": "code",
+        "outputId": "807e2137-dd7f-448d-abac-eb4a4939b811",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let spatialDimCount = layer1.filter.rank - 2\n",
+        "let receptiveField = layer1.filter.shape[0..<spatialDimCount].contiguousSize\n",
+        "receptiveField"
+      ],
+      "execution_count": 22,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "25\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 22
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "9_zRcFpQQ4nD",
+        "colab_type": "code",
+        "outputId": "ceeaae80-36eb-4819-a5d6-e949a711894e",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let filtersIn = layer1.filter.shape[2]\n",
+        "let filtersOut = layer1.filter.shape[3]\n",
+        "print(filtersIn, filtersOut)"
+      ],
+      "execution_count": 23,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "1 32\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "LyGL0ZTOQ4nG",
+        "colab_type": "code",
+        "outputId": "65fa1721-c313-49e4-d2de-7d7127a999bd",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let fanIn = filtersIn * receptiveField\n",
+        "let fanOut = filtersOut * receptiveField\n",
+        "print(fanIn, fanOut)"
+      ],
+      "execution_count": 24,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "25 800\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "QofS_8oWQ4nK",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "func gain(_ negativeSlope: Double) -> Double {\n",
+        "    return sqrt(2.0 / (1.0 + pow(negativeSlope, 2.0)))\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "jxjD3KizQ4nM",
+        "colab_type": "code",
+        "outputId": "3f44c440-dc44-47b4-f8af-9c40f6a10db6",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 119
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "(gain(1.0), gain(0.0), gain(0.01), gain(0.1), gain(sqrt(5.0)))"
+      ],
+      "execution_count": 26,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 5 elements\n",
+              "  - .0 : 1.0\n",
+              "  - .1 : 1.4142135623730951\n",
+              "  - .2 : 1.4141428569978354\n",
+              "  - .3 : 1.4071950894605838\n",
+              "  - .4 : 0.5773502691896257\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 26
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "2GD4vwqAQ4nP",
+        "colab_type": "code",
+        "outputId": "02048831-6558-4f49-bd10-0f5efc7d4b53",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "sqrt((2 * Tensor<Float>(randomUniform: [10000]) - 1).variance())"
+      ],
+      "execution_count": 27,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "0.57510734\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 27
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "mcgdFTeoQ4nS",
+        "colab_type": "code",
+        "outputId": "8fc69990-dad8-4947-cc8b-2abfeae0abd1",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 34
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "1.0 / sqrt(3.0)"
+      ],
+      "execution_count": 28,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "0.5773502691896258\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 28
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "1Sjf0Po4Q4nU",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "extension Tensor where Scalar: TensorFlowFloatingPoint {\n",
+        "    init(kaimingUniform shape: TensorShape, negativeSlope: Double = 1.0) {\n",
+        "        // Assumes Leaky ReLU nonlinearity\n",
+        "        let gain = Scalar(sqrt(2.0 / (1.0 + pow(negativeSlope, 2))))\n",
+        "        let spatialDimCount = shape.count - 2\n",
+        "        let receptiveField = shape[0..<spatialDimCount].contiguousSize\n",
+        "        let fanIn = shape[shape.count - 2] * receptiveField\n",
+        "        let bound = sqrt(Scalar(3.0)) * gain / sqrt(Scalar(fanIn))\n",
+        "        self = bound * (2 * Tensor(\n",
+        "            randomUniform: shape,\n",
+        "            generator: &PhiloxRandomNumberGenerator.global\n",
+        "        ) - 1)\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "wWsRNJXJQ4nW",
+        "colab_type": "code",
+        "outputId": "fcac0d39-e65b-4e53-9893-9025afa2aa90",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "layer1.filter = Tensor(kaimingUniform: layer1.filter.shape, negativeSlope: 0.0)\n",
+        "leakyRelu(layer1.applied(to: x)).stats()"
+      ],
+      "execution_count": 30,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  - mean : 0.4965667\n",
+              "  - std : 0.893754\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 30
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "TWuiGbPvQ4nZ",
+        "colab_type": "code",
+        "outputId": "db59923c-5e92-4fce-fcf3-4b13ebc2471e",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "layer1.filter = Tensor(kaimingUniform: layer1.filter.shape, negativeSlope: sqrt(5.0))\n",
+        "leakyRelu(layer1.applied(to: x)).stats()"
+      ],
+      "execution_count": 31,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  - mean : 0.20423418\n",
+              "  - std : 0.40728986\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 31
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "H3uL-bwcQ4nd",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "struct Model: Layer {\n",
+        "    var conv1 = Conv2D<Float>(\n",
+        "        filterShape: (5, 5, 1, 8),\n",
+        "        strides: (2, 2),\n",
+        "        padding: .same,\n",
+        "        activation: relu\n",
+        "    )\n",
+        "    var conv2 = Conv2D<Float>(\n",
+        "        filterShape: (3, 3, 8, 16),\n",
+        "        strides: (2, 2),\n",
+        "        padding: .same,\n",
+        "        activation: relu\n",
+        "    )\n",
+        "    var conv3 = Conv2D<Float>(\n",
+        "        filterShape: (3, 3, 16, 32),\n",
+        "        strides: (2, 2),\n",
+        "        padding: .same,\n",
+        "        activation: relu\n",
+        "    )\n",
+        "    var conv4 = Conv2D<Float>(\n",
+        "        filterShape: (3, 3, 32, 1),\n",
+        "        strides: (2, 2),\n",
+        "        padding: .valid\n",
+        "    )\n",
+        "    var flatten = Flatten<Float>()\n",
+        "    @differentiable\n",
+        "    func applied(to input: Tensor<Float>, in context: Context) -> Tensor<Float> {\n",
+        "        return input.sequenced(\n",
+        "            in: context,\n",
+        "            through: conv1, conv2, conv3, conv4, flatten\n",
+        "        )\n",
+        "    }\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "6S-iKZ7vQ4nf",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "let y = testY[0..<100]\n",
+        "var model = Model()"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "nlJq1T1mQ4nh",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        },
+        "outputId": "1d2fb9bc-6718-4ff1-f838-52db0ac5c92a"
+      },
+      "cell_type": "code",
+      "source": [
+        "let prediction = model.applied(to: x)\n",
+        "prediction.stats()"
+      ],
+      "execution_count": 51,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  - mean : -0.05856763\n",
+              "  - std : 0.09596065\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 51
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "oGWFCVbXQ4nn",
+        "colab_type": "code",
+        "outputId": "3be030be-f5ee-482a-c359-cc84e93e8e35",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 130
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let gradients = gradient(at: model) { model in\n",
+        "    meanSquaredError(predicted: model.applied(\n",
+        "        to: x,\n",
+        "        in: Context(learningPhase: .training)\n",
+        "    ), expected: y)\n",
+        "}\n",
+        "// Blocked by TF-417\n",
+        "gradients.conv1.filter.stats()"
+      ],
+      "execution_count": 63,
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "",
+          "evalue": "ignored",
+          "traceback": [
+            "error: <Cell 63>:7:11: error: 'conv1' is inaccessible due to 'internal' protection level\ngradients.conv1.filter.stats()\n          ^\n\n"
+          ]
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "Trb62tobQ4nv",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "for keyPath in [\\Model.conv1, \\Model.conv2, \\Model.conv3, \\Model.conv4] {\n",
+        "    model[keyPath: keyPath].filter = Tensor(kaimingUniform: model[keyPath: keyPath].filter.shape)\n",
+        "}"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "metadata": {
+        "id": "cKnzxCSXQ4nw",
+        "colab_type": "code",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 68
+        },
+        "outputId": "70b03d93-5c59-4b9b-a6cd-3f3c6ee89044"
+      },
+      "cell_type": "code",
+      "source": [
+        "let prediction = model.applied(to: x)\n",
+        "prediction.stats()"
+      ],
+      "execution_count": 66,
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "data": {
+            "text/plain": [
+              "▿ 2 elements\n",
+              "  - mean : -1.596702\n",
+              "  - std : 0.6037773\n"
+            ]
+          },
+          "metadata": {
+            "tags": []
+          },
+          "execution_count": 66
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "ocKEsSduQ4n0",
+        "colab_type": "code",
+        "outputId": "fe626cb5-257e-4555-db43-20c853416dba",
+        "colab": {
+          "base_uri": "https://localhost:8080/",
+          "height": 130
+        }
+      },
+      "cell_type": "code",
+      "source": [
+        "let gradients = gradient(at: model) { model in\n",
+        "    meanSquaredError(predicted: model.applied(\n",
+        "        to: x,\n",
+        "        in: Context(learningPhase: .training)\n",
+        "    ), expected: y)\n",
+        "}\n",
+        "// Blocked by TF-417\n",
+        "gradients.conv1.filter.stats()"
+      ],
+      "execution_count": 67,
+      "outputs": [
+        {
+          "output_type": "error",
+          "ename": "",
+          "evalue": "ignored",
+          "traceback": [
+            "error: <Cell 67>:8:11: error: 'conv1' is inaccessible due to 'internal' protection level\ngradients.conv1.filter.stats()\n          ^\n\n"
+          ]
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "jME24MwoQ4n8",
+        "colab_type": "text"
+      },
+      "cell_type": "markdown",
+      "source": [
+        "## Export"
+      ]
+    },
+    {
+      "metadata": {
+        "id": "PSH1eDarQ4n9",
+        "colab_type": "code",
+        "outputId": "0d189585-1890-4ec1-c19b-47b457125c8d",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        "!./notebook2script.py 02_fully_connected.ipynb"
+      ],
+      "execution_count": 0,
+      "outputs": [
+        {
+          "output_type": "stream",
+          "text": [
+            "Converted 02_fully_connected.ipynb to nb_02.py\r\n"
+          ],
+          "name": "stdout"
+        }
+      ]
+    },
+    {
+      "metadata": {
+        "id": "gfKqAeONQ4oA",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "cell_type": "code",
+      "source": [
+        ""
+      ],
+      "execution_count": 0,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
Currently meant to work as a standalone Colab, but I can also integrate it with the notebook-as-package infrastructure. Also includes a 10-line MNIST loader in plain Swift, which should likely replace `MnistDataset()`. More coming tomorrow.

Printing the values of individual weight gradients is blocked by TF-417.