### PR TITLE
A class- / protocol-oriented design for callbacks.

### DIFF
--- a/dev_swift/04_callbacks.ipynb
+++ b/dev_swift/04_callbacks.ipynb
@@ -18,6 +18,15 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
+   "outputs": [],
+   "source": [
+    "import TensorFlow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
    "outputs": [
     {
      "ename": "",
@@ -29,8 +38,6 @@
     }
    ],
    "source": [
-    "import TensorFlow\n",
-    "\n",
     "enum CallbackKind {\n",
     "    case begin_batch\n",
     "    case after_pred\n",
@@ -817,6 +824,12 @@
    "display_name": "Swift",
    "language": "swift",
    "name": "swift"
+  },
+  "language_info": {
+   "file_extension": ".swift",
+   "mimetype": "text/x-swift",
+   "name": "swift",
+   "version": ""
   }
  },
  "nbformat": 4,

--- a/dev_swift/04_callbacks.ipynb
+++ b/dev_swift/04_callbacks.ipynb
@@ -27,16 +27,52 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "",
-     "evalue": "ignored",
-     "output_type": "error",
-     "traceback": [
-      "warning: <Cell 1>:137:47: warning: redundant conformance constraint 'Model': 'Layer'\nfinal class AverageStatisticsCallback<Model : Layer, Opt : Optimizer> : TrainerCallback<Model, Opt>\n                                              ^\n\n<Cell 1>:137:60: note: conformance constraint 'Model': 'Layer' implied here\nfinal class AverageStatisticsCallback<Model : Layer, Opt : Optimizer> : TrainerCallback<Model, Opt>\n                                                           ^\n\nerror: <Cell 1>:128:33: error: value of type 'Model.Input' has no member 'shape'\n        let batchSize = trainer.data.shape[0]\n                        ~~~~~~~~^~~~ ~~~~~\n\nerror: <Cell 1>:199:27: error: cannot assign value of type 'Tensor<Float>' to type 'Model.Input'\n        self.data = batch.data\n                    ~~~~~~^~~~\n                               as! Model.Input\n\nerror: <Cell 1>:200:29: error: cannot assign value of type 'Tensor<Float>' to type 'Model.Output'\n        self.labels = batch.labels\n                      ~~~~~~^~~~~~\n                                   as! Model.Output\n\nwarning: <Cell 1>:203:33: warning: 'applied(to:)' is deprecated: Switch to 'applied(to:in:)' for training, or 'inferring(from:)' for inference\n        self.prediction = model.applied(to: self.data)\n                                ^\n\nwarning: <Cell 1>:214:13: warning: initialization of immutable value 'iterationCount' was never used; consider replacing with assignment to '_' or removing it\n        let iterationCount = batches.count\n        ~~~~^~~~~~~~~~~~~~\n        _\n\n"
-     ]
-    }
-   ],
+   "outputs": [],
+   "source": [
+    "// export\n",
+    "// Should this be a protocol or struct instead?\n",
+    "// How should multiple sets of callbacks be composed? (e.g. Should there be a class that takes a list of TrainingCallbacks and calls the respective methods and aggregates the returned values?)\n",
+    "// Can we group common sets of callbacks if they're commonly overridden together?\n",
+    "public class TrainingCallbacks<Model: Layer, Opt: Optimizer> {\n",
+    "    /// CallbackResult allows callbacks to control the training loop.\n",
+    "    enum CallbackResult {\n",
+    "        /// Proceed with the training step.\n",
+    "        case proceed\n",
+    "        /// Skip the rest of the training step, and move immediately to the next step.\n",
+    "        case skip\n",
+    "        /// Stop training.\n",
+    "        case stop\n",
+    "    }\n",
+    "    \n",
+    "    func preprocessBatch(batch: inout Model.Input) -> CallbackResult {\n",
+    "        return .proceed\n",
+    "    }\n",
+    "    \n",
+    "    func preprocessPrediction(prediction: inout Model.Output) -> CallbackResult {\n",
+    "        return .proceed\n",
+    "    }\n",
+    "    \n",
+    "    func preprocessLoss(loss: inout Float) -> CallbackResult {\n",
+    "        // TODO: make generic over loss type?\n",
+    "        return .proceed\n",
+    "    }\n",
+    "    \n",
+    "    // Is TangentVector the right type? Should we also pass in the model?\n",
+    "    func preprocessGradients(gradients: inout Model.TangentVector) -> CallbackResult {\n",
+    "        return .proceed\n",
+    "    }\n",
+    "    \n",
+    "    // What about the \"afterStep\" and \"afterBatch\" call backs? What should their type signatures be?\n",
+    "    \n",
+    "    // ...\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "enum CallbackKind {\n",
     "    case begin_batch\n",
@@ -306,16 +342,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "ename": "",
-     "evalue": "ignored",
-     "output_type": "error",
-     "traceback": [
-      "error: <Cell 1>:1:10: error: consecutive statements on a line must be separated by ';'\n%load_ext autoreload\n         ^\n         ;\n\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%load_ext autoreload\n",
     "%autoreload 2\n",
@@ -446,15 +473,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 tensor(0.1720) tensor(0.9471)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "loss,acc = fit(1, learn)"
    ]
@@ -759,20 +778,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "train: [0.312986328125, tensor(0.9031)]\n",
-      "valid: [0.145713427734375, tensor(0.9578)]\n",
-      "train: [0.13666587890625, tensor(0.9582)]\n",
-      "valid: [0.11328406982421875, tensor(0.9675)]\n",
-      "train: [0.10290517578125, tensor(0.9683)]\n",
-      "valid: [0.09884705810546875, tensor(0.9717)]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "run.fit(3, learn)"
    ]
@@ -798,15 +804,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Converted 04_callbacks.ipynb to nb_04.py\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "!./notebook2script.py 04_callbacks.ipynb"
    ]


### PR DESCRIPTION
There are a lot of different ways to design a callback API. This change explores
one direction of having a well-typed API. There are a lot of different tradeoffs
and I'm especially interested in getting everyone's great ideas together.

If I understand correctly, the callbacks in the fast.ai python framework can
control the training loop, and even modify the model or training data. This thus
results in a variety of API design choices. One principle we adopt is that the
callbacks should be well typed, and take specific arguments and return well
defined responses. That said, there are a number of ways to actually define the
interface. To illustrate them, we pick the callback that can inspect the batch
of training data, and optionally modify it. Below are a few alternates:

 1. `func preprocessBatch(batch: Model.Input) -> Model.Input?`
   In this spelling, the callback takes the batch, and optionally returns it.
   This allows the callback to optionally modify the batch, as well as return
   `nil` to short-circuit the training loop.

2.  `func preprocessBatch(batch: Model.Input) -> BatchResult<Model.Input>`
   In this spelling, the callback takes the batch, and returns a value from the
   enum `BatchResult`, which can take values: `.continue(input: Model.Input)`,
   `.skip` which skips the batch and continues on to the next minibatch, and
   `.stop` which exits the training loop. This formulation gives a lot more
   expressiveness to the callbacks to control the training loop.

    Variant: add a `.continueUnmodified` so the callback can be clearer in the
    default case when it doesn't modify the training data.

3.  `func preprocessBatch(batch: Model.Input) -> Model.Input throws`
   In this spelling, the callback can throw in order to signal a non-default
   condition and/or control the training loop. We could define special values
   that the callback should throw.

All of the above require the callback formulations assume the batch is passed
by value. However, we could alternately use `inout`, as this simplifies the
type signatures for the return values. (e.g. No need to redundantly specify the
`Model.Input` type in the return value in addition to the parameter type.) Note
that `inout` is short for copy-in-copy-out (with optimizations), which is
exactly the semantics we want. We thus have a few alternatives for how to write
the APIs with `inout`:

4.  `func preprocessBatch(batch: inout Model.Input) -> bool`
   Return a boolean to continue or not. This has a couple disadvantages
   including not being able to halt the training loop (or skip the batch), but
   perhaps more importantly, it's confusing to the users of the API (both
   implementers as well as consumers of the API) whether `true` means continue
   or `true` means skip/halt.

5.  This final alternative is the one proposed in the PR, where the function is
    written: `func preprocessBatch(batch: inout Model.Input -> CallbackResult`
    where `CallbackResult` is an enum with the possible values of: `.continue`,
    `.stop`, and `.skip`.

That said, there are a number of open design questions that we should carefully
evaluate including (but not limited to):

 1. Would it make sense to group some of the callbacks together because they're
    often overridden together?
 2. Should this be a protocol instead of a class? (Note: we'd have to use
    associated types, which has implications on the ergonomics of usage.)
 3. How can we gracefully handle composition of multiple sets of callbacks? In
    the comments I propose chaining them together serially, which some
    reasonable way to aggregate the `CallbackResult`s.