### PR TITLE
[Swift] Add training loop abstraction.

### DIFF
--- a/dev_swift/05b_early_stopping.ipynb
+++ b/dev_swift/05b_early_stopping.ipynb
@@ -1,0 +1,144 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training loop callbacks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// TODO.\n",
+    "// Integrate callbacks into `train` function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Training loops"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import TensorFlow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Softmax cross entropy loss function.\n",
+    "// TODO: This should be moved into the TensorFlow library/APIs.\n",
+    "@differentiable(vjp: _vjpSoftmaxCrossEntropy)\n",
+    "func softmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(\n",
+    "    features: Tensor<Scalar>, labels: Tensor<Scalar>\n",
+    ") -> Tensor<Scalar> {\n",
+    "    return Raw.softmaxCrossEntropyWithLogits(features: features, labels: labels).loss.mean()\n",
+    "}\n",
+    "\n",
+    "@usableFromInline\n",
+    "func _vjpSoftmaxCrossEntropy<Scalar: TensorFlowFloatingPoint>(\n",
+    "    features: Tensor<Scalar>, labels: Tensor<Scalar>\n",
+    ") -> (Tensor<Scalar>, (Tensor<Scalar>) -> (Tensor<Scalar>, Tensor<Scalar>)) {\n",
+    "    let (loss, grad) = Raw.softmaxCrossEntropyWithLogits(features: features, labels: labels)\n",
+    "    let batchSize = Tensor<Scalar>(features.shapeTensor[0])\n",
+    "    return (loss.mean(), { v in ((v / batchSize) * grad, Tensor<Scalar>(0)) })\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Example type for use with `Dataset`.\n",
+    "// TODO: The usage of this should be re-evaluated.\n",
+    "public struct Example<DataScalar, LabelScalar>: TensorGroup\n",
+    "    where DataScalar: TensorFlowFloatingPoint,\n",
+    "          LabelScalar: TensorFlowFloatingPoint {\n",
+    "    public var data: Tensor<DataScalar>\n",
+    "    public var labels: Tensor<LabelScalar>\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "/// A training loop.\n",
+    "///\n",
+    "/// Trains the given model at the given key path to all differentiable variables, on the given\n",
+    "/// dataset, using the given optimizer and loss function.\n",
+    "public func train<M, O: Optimizer, S>(\n",
+    "    _ model: inout M,\n",
+    "    at variablesKeyPath: WritableKeyPath<M, M.AllDifferentiableVariables>,\n",
+    "    on dataset: Dataset<Example<S, S>>,\n",
+    "    using optimizer: inout O,\n",
+    "    loss: @escaping @differentiable (Tensor<S>, Tensor<S>) -> Tensor<S>\n",
+    ") where O.Model == M, O.Scalar == S,\n",
+    "        M.Input == Tensor<S>, M.Output == Tensor<S>\n",
+    "{\n",
+    "    let context = Context(learningPhase: .training)\n",
+    "    for batch in dataset {\n",
+    "        let (x, y) = (batch.data, batch.labels)\n",
+    "        let (loss, (𝛁model, _)) = model.valueWithGradient(at: y) { (model, y) -> Tensor<S> in\n",
+    "            let preds = model.applied(to: x, in: context)\n",
+    "            return loss(preds, y)\n",
+    "        }\n",
+    "        print(loss)\n",
+    "        optimizer.update(&model[keyPath: variablesKeyPath], along: 𝛁model)\n",
+    "    }\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "// Example usage.\n",
+    "var model = Dense<Float>(inputSize: 784, outputSize: 10)\n",
+    "var optimizer = SGD<Dense<Float>, Float>(learningRate: 0.1)\n",
+    "\n",
+    "let data = Tensor<Float>(randomNormal: [10, 10, 784])\n",
+    "let labels = Tensor<Float>(randomNormal: [10, 10])\n",
+    "let dataset = Dataset<Example<Float, Float>>(elements: Example<Float, Float>(data: data, labels: labels))\n",
+    "\n",
+    "train(&model, at: \\Dense<Float>.allDifferentiableVariables, on: dataset, using: &optimizer, loss: softmaxCrossEntropy)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    ""
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Swift",
+   "name": "swift"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
Add `train` function, which trains a given model on a given dataset, using
a given optimizer and loss function.

Todos:
- Integrate callbacks into `train`.
  - `train` will be the analog of `class Runner`.
- Finish porting the Python `05b_early_stopping.ipynb` notebook.