### PR TITLE
Fixing a typo for `vars` vs. `varns`

### DIFF
--- a/dev_course/dl2/07_batchnorm.ipynb
+++ b/dev_course/dl2/07_batchnorm.ipynb
@@ -992,7 +992,7 @@
     "        self.batch += bs\n",
     "        means = self.sums/self.count\n",
     "        varns = (self.sqrs/self.count).sub_(means*means)\n",
-    "        if bool(self.batch < 20): vars.clamp_min_(0.01)\n",
+    "        if bool(self.batch < 20): varns.clamp_min_(0.01)\n",
     "        self.factor = self.mults / (varns+self.eps).sqrt()\n",
     "        self.offset = self.adds - means*self.factor\n",
     "        \n",


### PR DESCRIPTION
When running the simplified RunningBatchNorm, I was getting the following error:

```
<ipython-input-16-6c81ad8a7715> in update_stats(self, x)
     27         means = self.sums/self.count
     28         varns = (self.sqrs/self.count).sub_(means*means)
---> 29         if bool(self.batch < 20): vars.clamp_min_(0.01)
     30         self.factor = self.mults / (varns+self.eps).sqrt()
     31         self.offset = self.adds - means*self.factor

AttributeError: 'builtin_function_or_method' object has no attribute 'clamp_min_'
```

I believe it is supposed to be `varns` instead. 