### PR TITLE
Fix cross-platform random Int64 generation

### DIFF
--- a/dev_swift/04_callbacks.ipynb
+++ b/dev_swift/04_callbacks.ipynb
@@ -132,7 +132,7 @@
     "    private func processDs(_ ds: Dataset<Element>, _ shuffle: Bool) -> Dataset<Element>{\n",
     "        if !shuffle { return ds.batched(Int64(batchSize))}\n",
     "        let count = Int64(500000)  // A very large number\n",
-    "        return ds.shuffled(sampleCount: count, randomSeed: Int64(random())).batched(Int64(batchSize))\n",
+    "        return ds.shuffled(sampleCount: count, randomSeed: Int64.random(in: Int64.min..<Int64.max)).batched(Int64(batchSize))\n",
     "    }\n",
     "    \n",
     "    public init(train: Dataset<Element>, valid: Dataset<Element>, batchSize: Int = 64) {\n",

--- a/dev_swift/05_anneal.ipynb
+++ b/dev_swift/05_anneal.ipynb
@@ -354,7 +354,6 @@
    "outputs": [],
    "source": [
     "// export\n",
-    "import Glibc\n",
     "import Foundation"
    ]
   },


### PR DESCRIPTION

In the `DataBunch` definition, this replaces a call to `random()`  (which works on Linux but not on macOS), with the cross-platform expression `Int64.random(in:Int64.min..<Int64.max)`.

This also removes an Glibc import which had no effect on Linux and broke macOS.

This PR only updates the notebooks, and not the pre-generated Swift packages. (Should I update those too?)

I tested by running the 04 and the 05 notebooks. 04 works fine. 05 fails in the same way before and after the change, at cell 46, due to what I believe are unrelated issues with unresolved or identifiers.