### PR TITLE
Store 'house' dictionary index into a variable to fix test check

### DIFF
--- a/dev_course/dl2/12c_ulmfit.ipynb
+++ b/dev_course/dl2/12c_ulmfit.ipynb
@@ -174,7 +174,7 @@
     }
    ],
    "source": [
-    "vocab.index('house'),old_vocab.index('house')"
+    "idx_house_new, idx_house_old = vocab.index('house'),old_vocab.index('house')"
    ]
   },
   {
@@ -192,8 +192,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "house_wgt  = old_wgts['0.encoder.weight'][230]\n",
-    "house_bias = old_wgts['1.decoder.bias'][230] "
+    "house_wgt  = old_wgts['0.encoder.weight'][idx_house_old]\n",
+    "house_bias = old_wgts['1.decoder.bias'][idx_house_old] "
    ]
   },
   {
@@ -252,8 +252,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_near(wgts['0.encoder.weight'][346],house_wgt)\n",
-    "test_near(wgts['1.decoder.bias'][346],house_bias)"
+    "test_near(wgts['0.encoder.weight'][idx_house_new],house_wgt)\n",
+    "test_near(wgts['1.decoder.bias'][idx_house_new],house_bias)"
    ]
   },
   {
@@ -1702,6 +1702,47 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.0"
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/dev_course/dl2/12c_ulmfit.ipynb
+++ b/dev_course/dl2/12c_ulmfit.ipynb
@@ -1702,47 +1702,6 @@
    "display_name": "Python 3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.0"
-  },
-  "varInspector": {
-   "cols": {
-    "lenName": 16,
-    "lenType": 16,
-    "lenVar": 40
-   },
-   "kernels_config": {
-    "python": {
-     "delete_cmd_postfix": "",
-     "delete_cmd_prefix": "del ",
-     "library": "var_list.py",
-     "varRefreshCmd": "print(var_dic_list())"
-    },
-    "r": {
-     "delete_cmd_postfix": ") ",
-     "delete_cmd_prefix": "rm(",
-     "library": "var_list.r",
-     "varRefreshCmd": "cat(var_dic_list()) "
-    }
-   },
-   "types_to_exclude": [
-    "module",
-    "function",
-    "builtin_function_or_method",
-    "instance",
-    "_Feature"
-   ],
-   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Store **index of word 'house' into a variable** to ensure that the test check works even after retraining model of previous notebook.
```python
idx_house_new, idx_house_old = vocab.index('house'),old_vocab.index('house')
...
house_wgt  = old_wgts['0.encoder.weight'][idx_house_old]
house_bias = old_wgts['1.decoder.bias'][idx_house_old] 
...
test_near(wgts['0.encoder.weight'][idx_house_new],house_wgt)
test_near(wgts['1.decoder.bias'][idx_house_new],house_bias)
```