### PR TITLE
Update 05b_early_stopping.ipynb

### DIFF
--- a/dev_course/dl2/05b_early_stopping.ipynb
+++ b/dev_course/dl2/05b_early_stopping.ipynb
@@ -173,7 +173,7 @@
     "            self.learn = None\n",
     "\n",
     "    def __call__(self, cb_name):\n",
-    "        res = False\n",
+    "        res = True\n",
     "        for cb in sorted(self.cbs, key=lambda x: x._order): res = cb(cb_name) and res\n",
     "        return res"
    ]


### PR DESCRIPTION
I could be wrong but in the definition of the `Runner` class in the `__call__` method, is the variable `res` supposed to be initialized to True?   Maybe I'm missing something but the way I'm understanding it this code will always return false?  

```
    def __call__(self, cb_name):
        res = False
        for cb in sorted(self.cbs, key=lambda x: x._order): res = cb(cb_name) and res
        return res
```

Thanks