### PR TITLE
Fix access to lowercased as var rather than function call

### DIFF
--- a/dev_swift/08_data_block.ipynb
+++ b/dev_swift/08_data_block.ipynb
@@ -273,7 +273,7 @@
     "    for p in try! path.ls(){\n",
     "        if p.kind == .directory && recurse { \n",
     "            res += fetchFiles(path: p.path, recurse: recurse, extensions: extensions)\n",
-    "        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased) {\n",
+    "        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased()) {\n",
     "            res.append(p.path)\n",
     "        }\n",
     "    }\n",

--- a/dev_swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/08_data_block.swift
+++ b/dev_swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/08_data_block.swift
@@ -27,7 +27,7 @@ public func fetchFiles(path: Path, recurse: Bool = false, extensions: [String]? 
     for p in try! path.ls(){
         if p.kind == .directory && recurse { 
             res += fetchFiles(path: p.path, recurse: recurse, extensions: extensions)
-        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased) {
+        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased()) {
             res.append(p.path)
         }
     }

--- a/dev_swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/08_data_block.swift
+++ b/dev_swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/08_data_block.swift
@@ -27,7 +27,7 @@ public func fetchFiles(path: Path, recurse: Bool = false, extensions: [String]? 
     for p in try! path.ls(){
         if p.kind == .directory && recurse { 
             res += fetchFiles(path: p.path, recurse: recurse, extensions: extensions)
-        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased) {
+        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased()) {
             res.append(p.path)
         }
     }

--- a/dev_swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/08_data_block.swift
+++ b/dev_swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/08_data_block.swift
@@ -27,7 +27,7 @@ public func fetchFiles(path: Path, recurse: Bool = false, extensions: [String]? 
     for p in try! path.ls(){
         if p.kind == .directory && recurse { 
             res += fetchFiles(path: p.path, recurse: recurse, extensions: extensions)
-        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased) {
+        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased()) {
             res.append(p.path)
         }
     }

--- a/dev_swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/08_data_block.swift
+++ b/dev_swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/08_data_block.swift
@@ -27,7 +27,7 @@ public func fetchFiles(path: Path, recurse: Bool = false, extensions: [String]? 
     for p in try! path.ls(){
         if p.kind == .directory && recurse { 
             res += fetchFiles(path: p.path, recurse: recurse, extensions: extensions)
-        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased) {
+        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased()) {
             res.append(p.path)
         }
     }

--- a/dev_swift/FastaiNotebooks/Sources/FastaiNotebooks/08_data_block.swift
+++ b/dev_swift/FastaiNotebooks/Sources/FastaiNotebooks/08_data_block.swift
@@ -27,7 +27,7 @@ public func fetchFiles(path: Path, recurse: Bool = false, extensions: [String]? 
     for p in try! path.ls(){
         if p.kind == .directory && recurse { 
             res += fetchFiles(path: p.path, recurse: recurse, extensions: extensions)
-        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased) {
+        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased()) {
             res.append(p.path)
         }
     }


### PR DESCRIPTION
This PR fixes a bug in notebook 08 in `fetchFiles`, and updates all Swift files generated from that notebook.

It replaces a reference to a non-existent `.lowercased` property of `String` with the function call `lowercased()`. You can see there is such a function and no such property in the API docs: https://developer.apple.com/documentation/swift/string/1641392-lowercased.

So the real question is, why did this work at all? I don't know. I think it's a S4TF bug, or a consequence of the execution context of the jupyter environment.

I have tested and verified that all notebooks still run correctly on Ubuntu nightly 2019-04-21, and that the pre-generated Fastai Swift code still builds.

I found this bug while working on getting fastai running on macOS, where this produces a compilation error. I have got fastai building successfully on macOS, by the way, using the Xcode 2019-04-18 toolchain, and a couple build settings changes.