### PR TITLE
Fix access to String.lowercased as var not func

### DIFF
--- a/dev_swift/Runnable11/Sources/Runnable11/08_data_block.swift
+++ b/dev_swift/Runnable11/Sources/Runnable11/08_data_block.swift
@@ -27,7 +27,7 @@ public func fetchFiles(path: Path, recurse: Bool = false, extensions: [String]? 
     for p in try! path.ls(){
         if p.kind == .directory && recurse { 
             res += fetchFiles(path: p.path, recurse: recurse, extensions: extensions)
-        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased) {
+        } else if extensions == nil || extensions!.contains(p.path.extension.lowercased()) {
             res.append(p.path)
         }
     }


### PR DESCRIPTION
This is a boring fix.

String.lowercased() is a function call not a computed property.
Treating it as a property works in Jupyter, but it should not.
We've fixed this everywhere else. The generated Swift in Runnable
must be out of date with what's exported from the notebooks.

This problem only affects the ability to compile on macOS.