### PR TITLE
add self to learn references in callback definition

### DIFF
--- a/dev_course/dl2/04_callbacks.ipynb
+++ b/dev_course/dl2/04_callbacks.ipynb
@@ -257,7 +257,7 @@
     "\n",
     "    def begin_fit(self, learn):\n",
     "        self.learn,self.in_train = learn,True\n",
-    "        learn.stop = False\n",
+    "        self.learn.stop = False\n",
     "        res = True\n",
     "        for cb in self.cbs: res = res and cb.begin_fit(learn)\n",
     "        return res\n",
@@ -268,7 +268,7 @@
     "        return res\n",
     "    \n",
     "    def begin_epoch(self, epoch):\n",
-    "        learn.model.train()\n",
+    "        self.learn.model.train()\n",
     "        self.in_train=True\n",
     "        res = True\n",
     "        for cb in self.cbs: res = res and cb.begin_epoch(epoch)\n",
@@ -307,8 +307,8 @@
     "        return res\n",
     "    \n",
     "    def do_stop(self):\n",
-    "        try:     return learn.stop\n",
-    "        finally: learn.stop = False"
+    "        try:     return self.learn.stop\n",
+    "        finally: self.learn.stop = False"
    ]
   },
   {
@@ -326,7 +326,7 @@
     "    def after_step(self):\n",
     "        self.n_iters += 1\n",
     "        print(self.n_iters)\n",
-    "        if self.n_iters>=10: learn.stop = True\n",
+    "        if self.n_iters>=10: self.learn.stop = True\n",
     "        return True"
    ]
   },


### PR DESCRIPTION
Fixed references to `learn` referred to the learner object created outside the class definition. Now they refer to the internal `self.learn` instead.