### PR TITLE
fixed named parameters in 12b_lm_pretrain.ipynb

### DIFF
--- a/dev_course/dl2/12b_lm_pretrain.ipynb
+++ b/dev_course/dl2/12b_lm_pretrain.ipynb
@@ -234,7 +234,7 @@
     "cbs = [partial(AvgStatsCallback,accuracy_flat),\n",
     "       CudaCallback, Recorder,\n",
     "       partial(GradientClipping, clip=0.1),\n",
-    "       partial(RNNTrainer, α=2., β=1.),\n",
+    "       partial(RNNTrainer, alpha=2., beta=1.),\n",
     "       ProgressCallback]"
    ]
   },


### PR DESCRIPTION
The [__init__ for `RNNTrainer`](https://github.com/fastai/fastai_docs/blob/master/dev_course/dl2/exp/nb_12a.py#L145-L146
) has keyword arguments `alpha` and `beta` 

However, in the notebook trying we are initializing the `RNNTrainer` class with α=2., β=1.  This ends up resulting in an error because keyword args do not match, so this is a minor fix that addresses this.