### PR TITLE
Update the Just http dependency to be compatible with the latest S4TF…

### DIFF
--- a/dev_swift/00_load_data.ipynb
+++ b/dev_swift/00_load_data.ipynb
@@ -12,7 +12,7 @@
       "Installing packages:\n",
       "\t.package(url: \"https://github.com/mxcl/Path.swift\", from: \"0.16.1\")\n",
       "\t\tPath\n",
-      "\t.package(url: \"https://github.com/JustHTTP/Just\", from: \"0.7.1\")\n",
+      "\t.package(url: \"https://github.com/saeta/Just\", from: \"0.7.2\")\n",
       "\t\tJust\n",
       "\t.package(url: \"https://github.com/latenitesoft/NotebookExport\", from: \"0.5.0\")\n",
       "\t\tNotebookExport\n",
@@ -36,7 +36,7 @@
    "source": [
     "%install-location $cwd/swift-install\n",
     "%install '.package(url: \"https://github.com/mxcl/Path.swift\", from: \"0.16.1\")' Path\n",
-    "%install '.package(url: \"https://github.com/JustHTTP/Just\", from: \"0.7.1\")' Just\n",
+    "%install '.package(url: \"https://github.com/saeta/Just\", from: \"0.7.2\")' Just\n",
     "%install '.package(url: \"https://github.com/latenitesoft/NotebookExport\", from: \"0.5.0\")' NotebookExport"
    ]
   },


### PR DESCRIPTION
… builds.

Swift 5 has updated the location of a lot of code. As a result, the upcoming S4TF v0.4 toolchain will not work with the code as-written. This is the first of a series to update the notebooks to be compatible with the latest S4TF toolchains.