### PR TITLE
[Swift] Rename `unbroadcast` to `unbroadcasted`.

### DIFF
--- a/dev_swift/02_fully_connected.ipynb
+++ b/dev_swift/02_fully_connected.ipynb
@@ -1127,7 +1127,7 @@
     "            chain: { 𝛁out in\n",
     "              (𝛁out • w.transposed(), \n",
     "               inp.transposed() • 𝛁out,\n",
-    "               𝛁out.unbroadcast(to: b.shape))\n",
+    "               𝛁out.unbroadcasted(to: b.shape))\n",
     "    })\n",
     "}"
    ]


### PR DESCRIPTION
Confirmed no other usages of `unbroadcast`:
```console
$ grep -nr "unbroadcast" dev_swift/**/*.swift dev_swift/**/*.ipynb
dev_swift/02_fully_connected.ipynb:1179:    "               𝛁out.unbroadcasted(to: b.shape))\n",
```

Up next: investigating gradient computation assertion failures. ([TF-596](https://bugs.swift.org/browse/TF-596))