### PR TITLE
[Swift] Fix relu gradient definition.

### DIFF
--- a/dev_swift/02_fully_connected.ipynb
+++ b/dev_swift/02_fully_connected.ipynb
@@ -121,7 +121,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.13066047 0.3081079\r\n"
+      "0.13066049 0.30810732\n"
      ]
     }
    ],
@@ -251,7 +251,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.006017743 1.0076997\r\n"
+      "0.006017913 1.0077027\r\n"
      ]
     }
    ],
@@ -294,7 +294,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.00955411 0.9910275\r\n"
+      "0.18747045 1.0148597\r\n"
      ]
     }
    ],
@@ -330,7 +330,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.39847973 0.5892221\r\n"
+      "0.50279003 0.6542125\r\n"
      ]
     }
    ],
@@ -358,7 +358,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "-0.0001389117 0.05057716\r\n"
+      "-3.8356437e-05 0.05039108\r\n"
      ]
     }
    ],
@@ -375,7 +375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0.58910006 0.8475437\r\n"
+      "0.53144276 0.8092007\r\n"
      ]
     }
    ],
@@ -414,7 +414,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "average: 0.9904592000000001 ms,   min: 0.875356 ms,   max: 1.122177 ms\r\n"
+      "average: 3.7664891000000003 ms,   min: 2.993077 ms,   max: 4.940273 ms\r\n"
      ]
     }
    ],
@@ -483,7 +483,7 @@
     {
      "data": {
       "text/plain": [
-       "39.380497\n"
+       "31.958689\n"
       ]
      },
      "execution_count": null,

--- a/dev_swift/02_fully_connected.ipynb
+++ b/dev_swift/02_fully_connected.ipynb
@@ -566,7 +566,7 @@
     "\n",
     "func reluGrad(_ inp: TFGrad, _ out: TFGrad) {\n",
     "    //grad of relu with respect to input activations\n",
-    "    inp.grad = out.grad.replacing(with: TF(zeros: inp.inner.shape), where: (inp.inner .> 0))\n",
+    "    inp.grad = out.grad.replacing(with: TF(zeros: inp.inner.shape), where: (inp.inner .< 0))\n",
     "}"
    ]
   },
@@ -1093,7 +1093,7 @@
     "    return (value: max(x, 0),\n",
     "            // Pullback for max(x, 0)\n",
     "            chain: { 𝛁out -> TF in\n",
-    "              𝛁out.replacing(with: TF(zeros: x.shape), where: x .> 0)\n",
+    "              𝛁out.replacing(with: TF(zeros: x.shape), where: x .< 0)\n",
     "            })\n",
     "}"
    ]


### PR DESCRIPTION
`reluGrad` should replace with zero for negative input scalars instead
of positive input scalars.

---

Verified this fixes `dev_swift/02_fully_connected.ipynb`.

I wasn't sure whether to strip or keep cell outputs, so I used my best judgement to update selected outputs. @sgugger: could you please clarify what to do with cell outputs?