### PR TITLE
Export some Swift notebooks

### DIFF
--- a/dev_swift/01a_fastai_layers.ipynb
+++ b/dev_swift/01a_fastai_layers.ipynb
@@ -11,29 +11,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Installing packages:\n",
-      "\t.package(path: \"/usr/local/google/home/burmako/swift-jupyter/fastai_docs/dev_swift/FastaiNotebook_01_matmul\")\n",
-      "\t\tFastaiNotebook_01_matmul\n",
-      "With SwiftPM flags: []\n",
-      "Working in: /tmp/tmp0440clar/swift-install\n",
-      "[1/3] Compiling FastaiNotebook_01_matmul 01_matmul.swift\n",
-      "[2/3] Compiling FastaiNotebook_01_matmul 00_load_data.swift\n",
-      "[3/4] Merging module FastaiNotebook_01_matmul\n",
-      "[4/5] Compiling jupyterInstalledPackages jupyterInstalledPackages.swift\n",
-      "[5/6] Merging module jupyterInstalledPackages\n",
-      "[6/6] Linking libjupyterInstalledPackages.so\n",
-      "Initializing Swift...\n",
-      "Installation complete!\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_01_matmul\")' FastaiNotebook_01_matmul"
@@ -41,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +32,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +55,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +210,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +266,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -398,7 +378,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +457,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +500,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +526,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +578,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +606,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +642,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -718,17 +698,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "success\r\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import NotebookExport\n",
     "let exporter = NotebookExport(Path.cwd/\"01a_fastai_layers.ipynb\")\n",
@@ -748,12 +720,6 @@
    "display_name": "Swift",
    "language": "swift",
    "name": "swift"
-  },
-  "language_info": {
-   "file_extension": ".swift",
-   "mimetype": "text/x-swift",
-   "name": "swift",
-   "version": ""
   }
  },
  "nbformat": 4,

--- a/dev_swift/01a_fastai_layers.ipynb
+++ b/dev_swift/01a_fastai_layers.ipynb
@@ -11,9 +11,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Installing packages:\n",
+      "\t.package(path: \"/usr/local/google/home/burmako/swift-jupyter/fastai_docs/dev_swift/FastaiNotebook_01_matmul\")\n",
+      "\t\tFastaiNotebook_01_matmul\n",
+      "With SwiftPM flags: []\n",
+      "Working in: /tmp/tmp0440clar/swift-install\n",
+      "[1/3] Compiling FastaiNotebook_01_matmul 01_matmul.swift\n",
+      "[2/3] Compiling FastaiNotebook_01_matmul 00_load_data.swift\n",
+      "[3/4] Merging module FastaiNotebook_01_matmul\n",
+      "[4/5] Compiling jupyterInstalledPackages jupyterInstalledPackages.swift\n",
+      "[5/6] Merging module jupyterInstalledPackages\n",
+      "[6/6] Linking libjupyterInstalledPackages.so\n",
+      "Initializing Swift...\n",
+      "Installation complete!\n"
+     ]
+    }
+   ],
    "source": [
     "%install-location $cwd/swift-install\n",
     "%install '.package(path: \"$cwd/FastaiNotebook_01_matmul\")' FastaiNotebook_01_matmul"
@@ -21,7 +41,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -32,7 +52,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -82,7 +102,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +202,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +230,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +286,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +333,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +398,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -457,7 +477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,7 +546,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +598,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +626,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,7 +662,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -698,9 +718,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "success\r\n"
+     ]
+    }
+   ],
    "source": [
     "import NotebookExport\n",
     "let exporter = NotebookExport(Path.cwd/\"01a_fastai_layers.ipynb\")\n",
@@ -720,6 +748,12 @@
    "display_name": "Swift",
    "language": "swift",
    "name": "swift"
+  },
+  "language_info": {
+   "file_extension": ".swift",
+   "mimetype": "text/x-swift",
+   "name": "swift",
+   "version": ""
   }
  },
  "nbformat": 4,

--- a/dev_swift/FastaiNotebook_01_matmul/Package.swift
+++ b/dev_swift/FastaiNotebook_01_matmul/Package.swift
@@ -2,16 +2,16 @@
 import PackageDescription
 
 let package = Package(
-    name: "FastaiNotebook_01_matmul",
-    products: [
-        .library(name: "FastaiNotebook_01_matmul", targets: ["FastaiNotebook_01_matmul"]),
-    ],
+name: "FastaiNotebook_01_matmul",
+products: [
+.library(name: "FastaiNotebook_01_matmul", targets: ["FastaiNotebook_01_matmul"]),
+
+],
 dependencies: [
-    .package(path: "../FastaiNotebook_00_load_data")
+.package(path: "../FastaiNotebook_00_load_data")
 ],
 targets: [
-    .target(
-        name: "FastaiNotebook_01_matmul",
-        dependencies: ["FastaiNotebook_00_load_data"]),
-    ]
+.target(name: "FastaiNotebook_01_matmul", dependencies: ["FastaiNotebook_00_load_data"]),
+
+]
 )

--- a/dev_swift/FastaiNotebook_01_matmul/Sources/FastaiNotebook_01_matmul/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_01_matmul/Sources/FastaiNotebook_01_matmul/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_01a_fastai_layers/Sources/FastaiNotebook_01a_fastai_layers/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_01a_fastai_layers/Sources/FastaiNotebook_01a_fastai_layers/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_02_fully_connected/Package.swift
+++ b/dev_swift/FastaiNotebook_02_fully_connected/Package.swift
@@ -2,16 +2,16 @@
 import PackageDescription
 
 let package = Package(
-    name: "FastaiNotebook_02_fully_connected",
-    products: [
-        .library(name: "FastaiNotebook_02_fully_connected", targets: ["FastaiNotebook_02_fully_connected"]),
-    ],
+name: "FastaiNotebook_02_fully_connected",
+products: [
+.library(name: "FastaiNotebook_02_fully_connected", targets: ["FastaiNotebook_02_fully_connected"]),
+
+],
 dependencies: [
-    .package(path: "../FastaiNotebook_01a_fastai_layers")
+.package(path: "../FastaiNotebook_01a_fastai_layers")
 ],
 targets: [
-    .target(
-        name: "FastaiNotebook_02_fully_connected",
-        dependencies: ["FastaiNotebook_01a_fastai_layers"]),
-    ]
+.target(name: "FastaiNotebook_02_fully_connected", dependencies: ["FastaiNotebook_01a_fastai_layers"]),
+
+]
 )

--- a/dev_swift/FastaiNotebook_02_fully_connected/Sources/FastaiNotebook_02_fully_connected/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_02_fully_connected/Sources/FastaiNotebook_02_fully_connected/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_02_fully_connected/Sources/FastaiNotebook_02_fully_connected/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_02_fully_connected/Sources/FastaiNotebook_02_fully_connected/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_02a_why_sqrt5/Sources/FastaiNotebook_02a_why_sqrt5/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_02a_why_sqrt5/Sources/FastaiNotebook_02a_why_sqrt5/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_02a_why_sqrt5/Sources/FastaiNotebook_02a_why_sqrt5/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_02a_why_sqrt5/Sources/FastaiNotebook_02a_why_sqrt5/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_03_minibatch_training/Sources/FastaiNotebook_03_minibatch_training/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_03_minibatch_training/Sources/FastaiNotebook_03_minibatch_training/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_03_minibatch_training/Sources/FastaiNotebook_03_minibatch_training/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_03_minibatch_training/Sources/FastaiNotebook_03_minibatch_training/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_04_callbacks/Sources/FastaiNotebook_04_callbacks/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_04_callbacks/Sources/FastaiNotebook_04_callbacks/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_04_callbacks/Sources/FastaiNotebook_04_callbacks/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_04_callbacks/Sources/FastaiNotebook_04_callbacks/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_05_anneal/Sources/FastaiNotebook_05_anneal/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_05_anneal/Sources/FastaiNotebook_05_anneal/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_05_anneal/Sources/FastaiNotebook_05_anneal/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_05_anneal/Sources/FastaiNotebook_05_anneal/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_05b_early_stopping/Sources/FastaiNotebook_05b_early_stopping/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_05b_early_stopping/Sources/FastaiNotebook_05b_early_stopping/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_05b_early_stopping/Sources/FastaiNotebook_05b_early_stopping/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_05b_early_stopping/Sources/FastaiNotebook_05b_early_stopping/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_06_cuda/Sources/FastaiNotebook_06_cuda/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_07_batchnorm/Sources/FastaiNotebook_07_batchnorm/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_08_data_block/Sources/FastaiNotebook_08_data_block/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_08a_heterogeneous_dictionary/Sources/FastaiNotebook_08a_heterogeneous_dictionary/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_08c_data_block_generic/Sources/FastaiNotebook_08c_data_block_generic/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_09_optimizer/Sources/FastaiNotebook_09_optimizer/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_10_mixup_ls/Sources/FastaiNotebook_10_mixup_ls/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/00_load_data.swift
+++ b/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/00_load_data.swift
@@ -4,6 +4,8 @@ file to edit: 00_load_data.ipynb
 
 */
 
+
+
 precedencegroup ExponentiationPrecedence {
     associativity: right
     higherThan: MultiplicationPrecedence

--- a/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/01_matmul.swift
+++ b/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/01_matmul.swift
@@ -4,6 +4,8 @@ file to edit: 01_matmul.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/02_fully_connected.swift
+++ b/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/02_fully_connected.swift
@@ -4,6 +4,8 @@ file to edit: 02_fully_connected.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 

--- a/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/02a_why_sqrt5.swift
+++ b/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/02a_why_sqrt5.swift
@@ -4,6 +4,8 @@ file to edit: 02a_why_sqrt5.ipynb
 
 */
 
+
+
 import Foundation
 import TensorFlow
 import Path
@@ -18,11 +20,11 @@ func leakyRelu<T: TensorFlowFloatingPoint>(
 extension Tensor where Scalar: TensorFlowFloatingPoint {
     init(kaimingUniform shape: TensorShape, negativeSlope: Double = 1.0) {
         // Assumes Leaky ReLU nonlinearity
-        let gain = Scalar(sqrt(2.0 / (1.0 + pow(negativeSlope, 2))))
+        let gain = Scalar.init(TensorFlow.sqrt(2.0 / (1.0 + TensorFlow.pow(negativeSlope, 2))))
         let spatialDimCount = shape.count - 2
         let receptiveField = shape[0..<spatialDimCount].contiguousSize
         let fanIn = shape[shape.count - 2] * receptiveField
-        let bound = sqrt(Scalar(3.0)) * gain / sqrt(Scalar(fanIn))
+        let bound = TensorFlow.sqrt(Scalar(3.0)) * gain / TensorFlow.sqrt(Scalar(fanIn))
         self = bound * (2 * Tensor(randomUniform: shape, generator: &PhiloxRandomNumberGenerator.global) - 1)
     }
 }

--- a/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/03_minibatch_training.swift
+++ b/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/03_minibatch_training.swift
@@ -4,6 +4,8 @@ file to edit: 03_minibatch_training.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 
@@ -28,7 +30,21 @@ public func batchedRanges(start:Int, end:Int, bs:Int) -> UnfoldSequence<Range<In
 
 public struct DataBatch<Inputs: Differentiable & TensorGroup, Labels: TensorGroup>: TensorGroup {
     public var xb: Inputs
-    public var yb: Labels    
+    public var yb: Labels
     
     public init(xb: Inputs, yb: Labels){ (self.xb,self.yb) = (xb,yb) }
+    
+    // TODO: REMOVE ME!
+    public var _tensorHandles: [_AnyTensorHandle] {
+        xb._tensorHandles + yb._tensorHandles
+    }
+    
+    public init<C>(_handles: C) where C: RandomAccessCollection, C.Element: _AnyTensorHandle {
+        precondition(_handles.count == 2, "Unexpected number of handles in \(_handles).")
+        xb = Inputs.init(_owning: nil)
+        yb = Labels.init(_owning: nil)
+        // TODO: FIX ME!
+//         xb = Inputs.init(_handles: [_handles[0]])
+//         yb = Labels.init(_handles: [_handles[1]])
+    }
 }

--- a/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/04_callbacks.swift
+++ b/dev_swift/FastaiNotebook_11_imagenette/Sources/FastaiNotebook_11_imagenette/04_callbacks.swift
@@ -4,6 +4,8 @@ file to edit: 04_callbacks.ipynb
 
 */
 
+
+
 import Path
 import TensorFlow
 
@@ -16,7 +18,7 @@ public struct BasicModel: Layer {
     }
     
     @differentiable
-    public func call(_ input: Tensor<Float>) -> Tensor<Float> {
+    public func callAsFunction(_ input: Tensor<Float>) -> Tensor<Float> {
         return layer2(layer1(input))
     }
 }
@@ -110,7 +112,7 @@ public final class Learner<Label: TensorGroup,
     
     public private(set) var epochCount = 0
     public private(set) var currentEpoch = 0
-    public private(set) var currentGradient = Model.CotangentVector.zero
+    public private(set) var currentGradient = Model.TangentVector.zero
     public private(set) var currentLoss = Loss.zero
     public private(set) var inTrain = false
     public private(set) var pctEpochs = Float.zero


### PR DESCRIPTION
As part of my work on https://bugs.swift.org/browse/TF-598, I've been clicking through Swift notebooks. After some time, I did `git status` and noticed that some Swift files are dirty. I figured that this may be unintentional and decided to submit this PR. 

Because of https://bugs.swift.org/browse/TF-603, I only got up until 04_callbacks. 05_anneal doesn't compile at the moment. If this PR ends up being useful, I will try to find time to continue with export after TF-603 is fixed.